### PR TITLE
Forwarder contract

### DIFF
--- a/contracts/contracts/Identity.sol
+++ b/contracts/contracts/Identity.sol
@@ -11,9 +11,12 @@ contract Identity is ERC725 {
     bytes32 constant KEY_OWNER = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
     mapping(bytes32 => bytes32) store;
+    bool initialised;
 
-    constructor(address owner) public {
-        store[KEY_OWNER] = bytes32(owner);
+    function initialise(address owner) public {
+      require(!initialised, "Contract already initialised");
+      store[KEY_OWNER] = bytes32(owner);
+      initialised = true;
     }
 
     modifier onlyOwner() {

--- a/contracts/contracts/Identity.sol
+++ b/contracts/contracts/Identity.sol
@@ -11,12 +11,12 @@ contract Identity is ERC725 {
     bytes32 constant KEY_OWNER = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
     mapping(bytes32 => bytes32) store;
-    bool initialised;
+    bool initialized;
 
-    function initialise(address owner) public {
-      require(!initialised, "Contract already initialised");
+    function initialize(address owner) public {
+      require(!initialized, "Contract already initialized");
       store[KEY_OWNER] = bytes32(owner);
-      initialised = true;
+      initialized = true;
     }
 
     modifier onlyOwner() {

--- a/contracts/contracts/Identity.sol
+++ b/contracts/contracts/Identity.sol
@@ -15,8 +15,8 @@ contract Identity is ERC725 {
 
     function initialize(address owner) public {
       require(!initialized, "Contract already initialized");
-      store[KEY_OWNER] = bytes32(owner);
       initialized = true;
+      store[KEY_OWNER] = bytes32(owner);
     }
 
     modifier onlyOwner() {

--- a/contracts/contracts/KeyManager.sol
+++ b/contracts/contracts/KeyManager.sol
@@ -25,12 +25,12 @@ contract KeyManager {
     _;
   }
 
-  function initialise() public {
+  function initialize() public {
     require(!initialized, "Contract already initialized");
+    initialized = true;
     bytes32 key = keccak256(abi.encodePacked(msg.sender));
     keys[key].keyType = ECDSA_TYPE;
     keys[key].purposes = MANAGEMENT_KEY;
-    initialized = true;
   }
 
   function getKey(bytes32 _key) public view returns (uint256 _purposes, uint256 _keyType) {

--- a/contracts/contracts/KeyManager.sol
+++ b/contracts/contracts/KeyManager.sol
@@ -16,6 +16,7 @@ contract KeyManager {
   }
 
   mapping (bytes32 => Key) keys;
+  bool initialised;
 
   modifier onlyManagementKeyOrSelf() {
     if (msg.sender != address(this)) {
@@ -24,10 +25,12 @@ contract KeyManager {
     _;
   }
 
-  constructor() public {
+  function initialise() public {
+    require(!initialised, "Contract already initialised");
     bytes32 key = keccak256(abi.encodePacked(msg.sender));
     keys[key].keyType = ECDSA_TYPE;
     keys[key].purposes = MANAGEMENT_KEY;
+    initialised = true;
   }
 
   function getKey(bytes32 _key) public view returns (uint256 _purposes, uint256 _keyType) {

--- a/contracts/contracts/KeyManager.sol
+++ b/contracts/contracts/KeyManager.sol
@@ -16,7 +16,7 @@ contract KeyManager {
   }
 
   mapping (bytes32 => Key) keys;
-  bool initialised;
+  bool initialized;
 
   modifier onlyManagementKeyOrSelf() {
     if (msg.sender != address(this)) {
@@ -26,11 +26,11 @@ contract KeyManager {
   }
 
   function initialise() public {
-    require(!initialised, "Contract already initialised");
+    require(!initialized, "Contract already initialized");
     bytes32 key = keccak256(abi.encodePacked(msg.sender));
     keys[key].keyType = ECDSA_TYPE;
     keys[key].purposes = MANAGEMENT_KEY;
-    initialised = true;
+    initialized = true;
   }
 
   function getKey(bytes32 _key) public view returns (uint256 _purposes, uint256 _keyType) {

--- a/contracts/helpers/forwarder.js
+++ b/contracts/helpers/forwarder.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const solc = require('solc');
+const truffleContract = require('truffle-contract');
+const compile = require('truffle-compile');
+
+async function getCoinbase() {
+  return new Promise(function (resolve, reject) {
+    web3.eth.getCoinbase(function (err, res) {
+      if (err) {
+        reject(err);
+      }
+      resolve(res);
+    });
+  });
+}
+
+function compileCode(source, options, coinbase) {
+  return new Promise(function (resolve, reject) {
+    compile(source, options, function (err, val) {
+      if (err) {
+        reject(err)
+      }
+      const Forwarder = truffleContract(val.Forwarder);
+      Forwarder.setProvider(web3.currentProvider);
+      Forwarder.defaults({
+        from: coinbase,
+        gas: 6721975
+      })
+      resolve(Forwarder)
+    });
+  });
+}
+
+async function createForwarder(address) {
+  const solidityCode = `
+  pragma solidity ^0.4.24;
+  contract Forwarder {
+    function() external payable {
+      require(msg.sig != 0x0, "Function signature not specified");
+      assembly {
+        calldatacopy(mload(0x40), 0, calldatasize)
+        let result := delegatecall(gas, ${address}, mload(0x40), calldatasize, mload(0x40), 0)
+        returndatacopy(mload(0x40), 0, returndatasize)
+        switch result
+        case 1 { return(mload(0x40), returndatasize) }
+        default { revert(mload(0x40), returndatasize) }
+      }
+    }
+  }
+  `;
+  const source = { 'Forwarder': solidityCode }
+  const options = {
+    'contracts_directory': 'contracts',
+    solc
+  }
+  const coinbase = await getCoinbase();
+  return compileCode(source, options, coinbase);
+}
+
+module.exports = createForwarder;

--- a/contracts/helpers/utils.js
+++ b/contracts/helpers/utils.js
@@ -1,0 +1,41 @@
+const truffleContract = require('truffle-contract');
+const compile = require('truffle-compile');
+
+function getEncodedCall(web3, instance, method, params = []) {
+  const contract = new web3.eth.Contract(instance.abi)
+  return contract.methods[method](...params).encodeABI()
+}
+
+async function getCoinbase() {
+  return new Promise(function (resolve, reject) {
+    web3.eth.getCoinbase(function (err, res) {
+      if (err) {
+        reject(err);
+      }
+      resolve(res);
+    });
+  });
+}
+
+function compileCode(source, options, coinbase) {
+  return new Promise(function (resolve, reject) {
+    compile(source, options, function (err, val) {
+      if (err) {
+        reject(err)
+      }
+      const Forwarder = truffleContract(val.Forwarder);
+      Forwarder.setProvider(web3.currentProvider);
+      Forwarder.defaults({
+        from: coinbase,
+        gas: 6721975
+      })
+      resolve(Forwarder)
+    });
+  });
+}
+
+module.exports = {
+  getEncodedCall,
+  getCoinbase,
+  compileCode
+};

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -185,6 +185,15 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -1373,6 +1382,31 @@
         }
       }
     },
+    "ethjs-abi": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        }
+      }
+    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -2393,6 +2427,15 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
+    "graphlib": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.11.1"
+      }
+    },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
@@ -3384,6 +3427,15 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -5432,6 +5484,186 @@
         "mocha": "^4.1.0",
         "original-require": "1.0.1",
         "solc": "0.4.24"
+      }
+    },
+    "truffle-blockchain-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
+      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc=",
+      "dev": true
+    },
+    "truffle-compile": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/truffle-compile/-/truffle-compile-3.0.13.tgz",
+      "integrity": "sha1-rOcluhipXN5fm/H/CXJL0pH2lU4=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "colors": "^1.1.2",
+        "debug": "^3.1.0",
+        "graphlib": "^2.1.1",
+        "solc": "0.4.24",
+        "truffle-config": "^1.0.6",
+        "truffle-contract-sources": "^0.0.2",
+        "truffle-error": "^0.0.3",
+        "truffle-expect": "^0.0.4"
+      }
+    },
+    "truffle-config": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.6.tgz",
+      "integrity": "sha1-GB2n0xnAxV6yeB1cGIapx/MvpHA=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0",
+        "lodash": "4.17.10",
+        "original-require": "1.0.1",
+        "truffle-error": "^0.0.3",
+        "truffle-provider": "^0.0.6"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "truffle-contract": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
+      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
+      "dev": true,
+      "requires": {
+        "ethjs-abi": "0.1.8",
+        "truffle-blockchain-utils": "^0.0.5",
+        "truffle-contract-schema": "^2.0.1",
+        "truffle-error": "^0.0.3",
+        "web3": "0.20.6"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.20.6",
+          "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          }
+        }
+      }
+    },
+    "truffle-contract-schema": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
+      "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.1.1",
+        "crypto-js": "^3.1.9-1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "crypto-js": {
+          "version": "3.1.9-1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
+      }
+    },
+    "truffle-contract-sources": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/truffle-contract-sources/-/truffle-contract-sources-0.0.2.tgz",
+      "integrity": "sha1-zTdOlbM4gF5NG3Z8FEm26o/lGeQ=",
+      "dev": true,
+      "requires": {
+        "node-dir": "0.1.17"
+      }
+    },
+    "truffle-error": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
+      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o=",
+      "dev": true
+    },
+    "truffle-expect": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.4.tgz",
+      "integrity": "sha1-1bJ63qTFUvQ7cNwAh3I2t7aMdcg=",
+      "dev": true
+    },
+    "truffle-provider": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.6.tgz",
+      "integrity": "sha1-caku1nY2raXniQVpDXLqkirUphM=",
+      "dev": true,
+      "requires": {
+        "truffle-error": "^0.0.3",
+        "web3": "0.20.6"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.20.6",
+          "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          }
+        }
       }
     },
     "tunnel-agent": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -17,6 +17,8 @@
     "openzeppelin-solidity": "^2.0.0",
     "solium": "^1.1.8",
     "truffle": "^4.1.14",
+    "truffle-compile": "^3.0.13",
+    "truffle-contract": "^3.0.6",
     "web3": "^1.0.0-beta.36"
   }
 }

--- a/contracts/test/forwarder.js
+++ b/contracts/test/forwarder.js
@@ -1,0 +1,47 @@
+const {reverting} = require('../node_modules/openzeppelin-solidity/test/helpers/shouldFail');
+const createForwarder = require('../helpers/forwarder');
+
+const web3 = require('web3');
+
+const Identity = artifacts.require('Identity');
+const KeyManager = artifacts.require('KeyManager');
+
+contract('Forwarder', async (accounts) => {
+  it('should be able to use Identity contract with forwarder', async () => {
+    const identity = await Identity.new();
+    const Forwarder = await createForwarder(identity.address);
+    const forwarder = await Forwarder.new();
+
+    const identityForwarder = await Identity.at(forwarder.address);
+    await identityForwarder.initialise(accounts[0]);
+    await reverting(identityForwarder.initialise(accounts[0]));
+
+    await identityForwarder.setData('a', 'b');
+
+    const owner = await identityForwarder.getData(0x0);
+    const data = await identityForwarder.getData('a');
+
+    assert.equal(owner, web3.utils.padLeft(accounts[0], 64));
+    assert.equal(web3.utils.toUtf8(data), 'b');
+  });
+
+  it('should be able to use KeyManager contract with forwarder', async () => {
+    const keyManager = await KeyManager.new();
+    const Forwarder = await createForwarder(keyManager.address);
+    const forwarder = await Forwarder.new();
+
+    const keyManagerForwarder = await KeyManager.at(forwarder.address);
+    await keyManagerForwarder.initialise();
+    await reverting(keyManagerForwarder.initialise());
+
+    await keyManagerForwarder.setKey('a', 2, 2);
+
+    let keyData = await keyManagerForwarder.getKey(web3.utils.keccak256(accounts[0]));
+    assert.equal(keyData[0].toNumber(), 1);
+    assert.equal(keyData[1].toNumber(), 1);
+
+    keyData = await keyManagerForwarder.getKey('a');
+    assert.equal(keyData[0].toNumber(), 2);
+    assert.equal(keyData[1].toNumber(), 2);
+  });
+});

--- a/contracts/test/identity_test.js
+++ b/contracts/test/identity_test.js
@@ -1,4 +1,5 @@
 const {reverting} = require('../node_modules/openzeppelin-solidity/test/helpers/shouldFail');
+const {getEncodedCall} = require('../helpers/utils');
 var Identity = artifacts.require('Identity')
 var Counter = artifacts.require('Counter')
 var Web3 = require('web3')
@@ -7,18 +8,13 @@ const KEY_OWNER = '0x00000000000000000000000000000000000000000000000000000000000
 const OPERATION_CALL = 0
 const web3 = new Web3(Web3.givenProvider)
 
-const getEncodedCall = (web3, instance, method, params = []) => {
-  const contract = new web3.eth.Contract(instance.abi)
-  return contract.methods[method](...params).encodeABI()
-}
-
 contract('Identity', function(accounts) {
   let identity, counter
 
   beforeEach(async function() {
     // Deploy contracts
     identity = await Identity.new()
-    identity.initialise(accounts[0])
+    identity.initialize(accounts[0])
     counter = await Counter.new()
   })
 

--- a/contracts/test/identity_test.js
+++ b/contracts/test/identity_test.js
@@ -17,7 +17,8 @@ contract('Identity', function(accounts) {
 
   beforeEach(async function() {
     // Deploy contracts
-    identity = await Identity.new(accounts[0])
+    identity = await Identity.new()
+    identity.initialise(accounts[0])
     counter = await Counter.new()
   })
 

--- a/contracts/test/key-manager.js
+++ b/contracts/test/key-manager.js
@@ -12,6 +12,7 @@ contract("KeyManager", async (accounts) => {
   let keyManager;
   beforeEach(async () => {
     keyManager = await KeyManager.new();
+    keyManager.initialise();
   });
 
   it('should create management key for creator', async function() {

--- a/contracts/test/key-manager.js
+++ b/contracts/test/key-manager.js
@@ -12,7 +12,7 @@ contract("KeyManager", async (accounts) => {
   let keyManager;
   beforeEach(async () => {
     keyManager = await KeyManager.new();
-    keyManager.initialise();
+    keyManager.initialize();
   });
 
   it('should create management key for creator', async function() {


### PR DESCRIPTION
Closes #13 

Constructors are not supported by forwarder, so i had to introduce `initialize` function along with `initialized` variable.
Between contract deployment and initialization there is time available for malicious actor to call `initialize` before the person that deployed the contract. For the deployer, they will only lose the money used for deployment, they can always deploy another one. This is possible in theory, in practice - very unlikely, but still.
This can be solved by creating another contract that will create and initialize the desired contract inside the same function. Thoughts?