### PR TITLE
Upgraded to solc 0.5.1

### DIFF
--- a/contracts/contracts/ERC725.sol
+++ b/contracts/contracts/ERC725.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 interface ERC725 {
-    event DataSet(bytes32 indexed key, bytes32 indexed value);
+    event DataSet(bytes32 indexed key, address indexed value);
 
-    function getData(bytes32 _key) external view returns (bytes32 _value);
-    function setData(bytes32 _key, bytes32 _value) external;
-    function execute(uint256 _operationType, address _to, uint256 _value, bytes _data) external;
+    function getData(bytes32 _key) external view returns (address _value);
+    function setData(bytes32 _key, address _value) external;
+    function execute(uint256 _operationType, address _to, uint256 _value, bytes calldata _data) external;
 }

--- a/contracts/contracts/Identity.sol
+++ b/contracts/contracts/Identity.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./ERC725.sol";
 contract Identity is ERC725 {
@@ -9,30 +9,30 @@ contract Identity is ERC725 {
     uint256 constant OPERATION_CREATE = 2;
     bytes32 constant KEY_OWNER = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
-    mapping(bytes32 => bytes32) store;
+    mapping(bytes32 => address) store;
     bool initialized;
 
     function initialize(address owner) public {
         require(!initialized, "contract-already-initialized");
         initialized = true;
-        store[KEY_OWNER] = bytes32(owner);
+        store[KEY_OWNER] = owner;
     }
 
     modifier onlyOwner() {
-        require(msg.sender == address(store[KEY_OWNER]), "only-owner-allowed");
+        require(msg.sender == store[KEY_OWNER], "only-owner-allowed");
         _;
     }
 
-    function getData(bytes32 _key) external view returns (bytes32 _value) {
+    function getData(bytes32 _key) external view returns (address _value) {
         return store[_key];
     }
 
-    function setData(bytes32 _key, bytes32 _value) external onlyOwner {
+    function setData(bytes32 _key, address _value) external onlyOwner {
         store[_key] = _value;
         emit DataSet(_key, _value);
     }
 
-    function execute(uint256 _operationType, address _to, uint256 _value, bytes _data) external onlyOwner {
+    function execute(uint256 _operationType, address _to, uint256 _value, bytes calldata _data) external onlyOwner {
         if (_operationType == OPERATION_CALL)
             executeCall(_to, _value, _data);
         else if (_operationType == OPERATION_DELEGATECALL)
@@ -45,7 +45,7 @@ contract Identity is ERC725 {
 
     // copied from GnosisSafe
     // https://github.com/gnosis/safe-contracts/blob/v0.0.2-alpha/contracts/base/Executor.sol
-    function executeCall(address to, uint256 value, bytes data)
+    function executeCall(address to, uint256 value, bytes memory data)
         internal
         returns (bool success)
     {
@@ -57,7 +57,7 @@ contract Identity is ERC725 {
 
     // copied from GnosisSafe
     // https://github.com/gnosis/safe-contracts/blob/v0.0.2-alpha/contracts/base/Executor.sol
-    function executeDelegateCall(address to, bytes data)
+    function executeDelegateCall(address to, bytes memory data)
         internal
         returns (bool success)
     {
@@ -69,7 +69,7 @@ contract Identity is ERC725 {
 
     // copied from GnosisSafe
     // https://github.com/gnosis/safe-contracts/blob/v0.0.2-alpha/contracts/base/Executor.sol
-    function executeCreate(bytes data)
+    function executeCreate(bytes memory data)
         internal
         returns (address newContract)
     {

--- a/contracts/contracts/KeyManager.sol
+++ b/contracts/contracts/KeyManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract KeyManager {
     event KeySet(bytes32 indexed key, uint256 indexed purposes, uint256 indexed keyType);
@@ -11,6 +11,11 @@ contract KeyManager {
     uint256 constant RSA_TYPE = 2;
 
     struct Key {
+        // Purposes are represented via bitmasks
+        // Maximum number of purposes is 256 and must be integers that are power of 2 e.g.:
+        // 1, 2, 4, 8, 16, 32, 64 ...
+        // All other integers represent multiple purposes e.g:
+        // Integer 3 (011) represent both 1 (001) and 2 (010) purpose
         uint256 purposes;
         uint256 keyType;
     }
@@ -39,8 +44,8 @@ contract KeyManager {
 
     function keyHasPurpose(bytes32 _key, uint256 _purpose) public view returns (bool) {
         // Only purposes that are power of 2 are allowed e.g.:
-        // 1, 2, 4, 8, 16, 32 64 ...
-        // Numbers that represent multiple purposes are not allowed
+        // 1, 2, 4, 8, 16, 32, 64 ...
+        // Integers that represent multiple purposes are not allowed
         require(_purpose != 0 && (_purpose & (_purpose - uint256(1))) == 0, "purpose-must-be-power-of-2");
         return (keys[_key].purposes & _purpose) != 0;
     }

--- a/contracts/contracts/dummy/Counter.sol
+++ b/contracts/contracts/dummy/Counter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract Counter {
     uint count;

--- a/contracts/contracts/truffle/Migrations.sol
+++ b/contracts/contracts/truffle/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.1;
 
 contract Migrations {
   address public owner;

--- a/contracts/test/forwarder.js
+++ b/contracts/test/forwarder.js
@@ -14,14 +14,13 @@ contract('Forwarder', async (accounts) => {
     const identityForwarder = await Identity.at(forwarder.options.address);
     await checkErrorRevert(identityForwarder.initialize(accounts[0]), 'contract-already-initialized');
 
-    const value = `0x${toBN(1).toString(16, 64)}`;
-    await identityForwarder.setData('0x0a', value);
+    await identityForwarder.setData('0x0a', accounts[1]);
 
     const owner = await identityForwarder.getData('0x00');
     const data = await identityForwarder.getData('0x0a');
 
-    assert.equal(owner, `0x${toBN(accounts[0], 16).toString(16, 64)}`);
-    assert.equal(data, value);
+    assert.equal(owner, accounts[0]);
+    assert.equal(data, accounts[1]);
   });
 
   it('should be able to use KeyManager contract with forwarder', async () => {

--- a/contracts/truffle.js
+++ b/contracts/truffle.js
@@ -6,10 +6,5 @@ module.exports = {
     reporterOptions : {
       currency: 'USD'
     }
-  },
-  compilers: {
-    solc: {
-      version: "0.4.24"
-    }
   }
 }


### PR DESCRIPTION
Closes #18 

Solium still doesn't fully support Solidity 0.5, so it will find some errors.

@tyleryasaka Whats the reason behind value of `store` mapping being `bytes32` and not `address` in  `Identity` contract?