### PR TITLE
Using bytes, instead of bytes32

### DIFF
--- a/contracts/contracts/ERC725.sol
+++ b/contracts/contracts/ERC725.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.5.4;
 
 interface ERC725 {
-    event DataChanged(bytes32 indexed key, bytes32 indexed value);
+    event DataChanged(bytes32 indexed key, bytes value);
     event OwnerChanged(address indexed ownerAddress);
     event ContractCreated(address indexed contractAddress);
 
     function changeOwner(address _owner) external;
-    function getData(bytes32 _key) external view returns (bytes32 _value);
-    function setData(bytes32 _key, bytes32 _value) external;
+    function getData(bytes32 _key) external view returns (bytes memory _value);
+    function setData(bytes32 _key, bytes calldata _value) external;
     function execute(uint256 _operationType, address _to, uint256 _value, bytes calldata _data) external;
 }

--- a/contracts/contracts/Identity.sol
+++ b/contracts/contracts/Identity.sol
@@ -6,21 +6,37 @@ contract ProxyAccount is ERC725 {
     
     uint256 constant OPERATION_CALL = 0;
     uint256 constant OPERATION_CREATE = 1;
+    // bytes32 constant KEY_OWNER = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
-    mapping(bytes32 => bytes32) store;
+    mapping(bytes32 => bytes) store;
     
-    // the owner
     address public owner;
-    
     
     constructor(address _owner) public {
         owner = _owner;
     }
 
+
     modifier onlyOwner() {
         require(msg.sender == owner, "only-owner-allowed");
         _;
     }
+    
+    // function toAddress(bytes32 a) internal pure returns (address b){
+    //   assembly {
+    //         mstore(0, a)
+    //         b := mload(0)
+    //     }
+    //   return b;
+    // }
+    
+    // function toBytes32(address a) internal pure returns (bytes32 b){
+    //   assembly {
+    //         mstore(0, a)
+    //         b := mload(0)
+    //     }
+    //   return b;
+    // }
     
     // ----------------
     // Public functions
@@ -38,12 +54,12 @@ contract ProxyAccount is ERC725 {
     function getData(bytes32 _key)
         external
         view
-        returns (bytes32 _value)
+        returns (bytes memory _value)
     {
         return store[_key];
     }
 
-    function setData(bytes32 _key, bytes32 _value)
+    function setData(bytes32 _key, bytes calldata _value)
         external
         onlyOwner
     {


### PR DESCRIPTION
This changes the data set from `bytes32 => bytes32` to `bytes32 => bytes`, which makes it a lot more flexible.