### PR TITLE
fix: ERC725X and ERC725Y inherit Ownable first

### DIFF
--- a/implementations/contracts/ERC725/ERC725X.sol
+++ b/implementations/contracts/ERC725/ERC725X.sol
@@ -16,7 +16,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  *
  *  @author Fabian Vogelsteller <fabian@lukso.network>
  */
-contract ERC725X is ERC725XCore, Ownable {
+contract ERC725X is Ownable, ERC725XCore {
     /**
      * @notice Sets the owner of the contract
      * @param _newOwner the owner of the contract.

--- a/implementations/contracts/ERC725/ERC725Y.sol
+++ b/implementations/contracts/ERC725/ERC725Y.sol
@@ -16,7 +16,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  *
  *  @author Fabian Vogelsteller <fabian@lukso.network>
  */
-contract ERC725Y is ERC725YCore, Ownable {
+contract ERC725Y is Ownable, ERC725YCore {
     /**
      * @notice Sets the owner of the contract
      * @param _newOwner the owner of the contract.


### PR DESCRIPTION
This solves a solc compile error `TypeError: Linearization of inheritance graph impossible` by inheriting the "most base-like" contracts first to prevent errors from inheriting contract. 

See a similar fix here https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1128

---

I came across this issue with a contract that has a token implementation from OpenZeppelin and `ERC725Y` as part of its inheritance graph.