### PR TITLE
Contracts with initializer for proxy compatibility.

### DIFF
--- a/implementations/contracts/ERC725/ERC725AccountInit.sol
+++ b/implementations/contracts/ERC725/ERC725AccountInit.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// modules
+import "./ERC725Init.sol";
+import "../IERC1271.sol";
+
+// libraries
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../helpers/UtilsLib.sol";
+
+/**
+ * @title ERC725Account
+ * @dev Bundles ERC725X and ERC725Y, and ERC1271 and allows receiving native tokens.
+ *
+ *  @author Fabian Vogelsteller <fabian@lukso.network>
+ */
+
+// TODO add ERC777, ERC223, ERC721 functions?
+
+contract ERC725AccountInit is Initializable, ERC725Init, IERC1271  {
+
+    bytes4 internal constant _INTERFACE_ID_ERC1271 = 0x1626ba7e;
+    bytes4 internal constant _ERC1271FAILVALUE = 0xffffffff;
+
+    event ValueReceived(address indexed sender, uint256 indexed value);
+
+    function initialize(address _newOwner) virtual override public initializer {
+        ERC725Init.initialize(_newOwner);
+        // set SupportedStandards > ERC725Account
+        bytes32 key = bytes32(0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6); // SupportedStandards > ERC725Account
+        store[key] = abi.encodePacked(bytes4(0xafdeb5d6)); // bytes4(keccak256('ERC725Account')
+        emit DataChanged(key, store[key]);
+
+        _registerInterface(_INTERFACE_ID_ERC1271);
+    }
+
+    // /**
+    //  * @notice Sets the owner of the contract
+    //  * @param _newOwner the owner of the contract.
+    //  */
+    // constructor(address _newOwner)
+    // ERC725(_newOwner)
+    // {
+    //     // // set SupportedStandards > ERC725Account
+    //     // bytes32 key = bytes32(0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6); // SupportedStandards > ERC725Account
+    //     // store[key] = abi.encodePacked(bytes4(0xafdeb5d6)); // bytes4(keccak256('ERC725Account')
+    //     // emit DataChanged(key, store[key]);
+
+    //     // _registerInterface(_INTERFACE_ID_ERC1271);
+    // }
+
+    receive() external payable {
+        emit ValueReceived(_msgSender(), msg.value);
+    }
+
+    // TODO to be discussed
+    // function fallback() public {
+    //     address to = owner();
+    //     assembly {
+    //         calldatacopy(0, 0, calldatasize())
+    //         let result := staticcall(gas(), to, 0, calldatasize(), 0, 0)
+    //         returndatacopy(0, 0, returndatasize())
+    //         switch result
+    //         case 0  { revert (0, returndatasize()) }
+    //         default { return (0, returndatasize()) }
+    //     }
+    // }
+
+
+    /**
+    * @notice Checks if an owner signed `_data`.
+    * ERC1271 interface.
+    *
+    * @param _hash hash of the data signed//Arbitrary length data signed on the behalf of address(this)
+    * @param _signature owner's signature(s) of the data
+    */
+    function isValidSignature(bytes32 _hash, bytes memory _signature)
+        override
+        public
+        view
+        returns (bytes4 magicValue)
+    {
+        // if OWNER is a contract
+        if (UtilsLib.isContract(owner())) {
+            return supportsInterface(_INTERFACE_ID_ERC1271)
+            ? IERC1271(owner()).isValidSignature(_hash, _signature)
+            : _ERC1271FAILVALUE;
+
+        // if OWNER is a key
+        } else {
+            return owner() == ECDSA.recover(_hash, _signature)
+            ? _INTERFACE_ID_ERC1271
+            : _ERC1271FAILVALUE;
+        }
+    }
+}

--- a/implementations/contracts/ERC725/ERC725Init.sol
+++ b/implementations/contracts/ERC725/ERC725Init.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// modules
+import "./ERC725XInit.sol";
+import "./ERC725YInit.sol";
+
+/**
+ * @title ERC725 bundle
+ * @dev Bundles ERC725X and ERC725Y together into one smart contract
+ *
+ *  @author Fabian Vogelsteller <fabian@lukso.network>
+ */
+contract ERC725Init is Initializable, ERC725XInit, ERC725YInit {
+
+    /**
+     * // @notice Sets the owner of the contract
+     * // @param _newOwner the owner of the contract.
+     */
+    function initialize(address _newOwner) virtual override(ERC725XInit, ERC725YInit) public initializer {
+        ERC725XInit.initialize(_newOwner);
+        ERC725YInit.initialize(_newOwner);
+    }
+    // constructor(address _newOwner)
+    // ERC725X(_newOwner)
+    // ERC725Y(_newOwner)
+    // {}
+
+    // NOTE this implementation has not by default: receive() external payable {}
+}

--- a/implementations/contracts/ERC725/ERC725XInit.sol
+++ b/implementations/contracts/ERC725/ERC725XInit.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "./IERC725X.sol";
 
 // modules
-import "../../node_modules/@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 // libraries
@@ -22,7 +22,7 @@ import "solidity-bytes-utils/contracts/BytesLib.sol";
  *
  *  @author Fabian Vogelsteller <fabian@lukso.network>
  */
-contract ERC725XInit is Ownable, ERC165Storage, IERC725X  {
+contract ERC725XInit is OwnableUpgradeable, ERC165Storage, IERC725X  {
 
     bytes4 internal constant _INTERFACE_ID_ERC725X = 0x44c028fe;
 
@@ -31,10 +31,11 @@ contract ERC725XInit is Ownable, ERC165Storage, IERC725X  {
     uint256 constant OPERATION_CREATE2 = 2;
     uint256 constant OPERATION_CREATE = 3;
 
-    function initialize(address _newOwner) virtual override public initializer {
+    function initialize(address _newOwner) virtual public initializer {
+        __Ownable_init_unchained();
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
-            Ownable.initialize(_newOwner);
+            transferOwnership(_newOwner);
         }
         
         _registerInterface(_INTERFACE_ID_ERC725X);

--- a/implementations/contracts/ERC725/ERC725XInit.sol
+++ b/implementations/contracts/ERC725/ERC725XInit.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// interfaces
+import "./IERC725X.sol";
+
+// modules
+import "../../node_modules/@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+// libraries
+import "@openzeppelin/contracts/utils/Create2.sol";
+import "solidity-bytes-utils/contracts/BytesLib.sol";
+
+/**
+ * @title ERC725 X executor
+ * @dev Implementation of a contract module which provides the ability to call arbitrary functions at any other smart contract and itself,
+ * including using `delegatecall`, as well creating contracts using `create` and `create2`.
+ * This is the basis for a smart contract based account system, but could also be used as a proxy account system.
+ *
+ * `execute` MUST only be called by the owner of the contract set via ERC173.
+ *
+ *  @author Fabian Vogelsteller <fabian@lukso.network>
+ */
+contract ERC725XInit is Ownable, ERC165Storage, IERC725X  {
+
+    bytes4 internal constant _INTERFACE_ID_ERC725X = 0x44c028fe;
+
+    uint256 constant OPERATION_CALL = 0;
+    uint256 constant OPERATION_DELEGATECALL = 1;
+    uint256 constant OPERATION_CREATE2 = 2;
+    uint256 constant OPERATION_CREATE = 3;
+
+    function initialize(address _newOwner) virtual override public initializer {
+        // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
+        if (_newOwner != owner()) {
+            Ownable.initialize(_newOwner);
+        }
+        
+        _registerInterface(_INTERFACE_ID_ERC725X);
+    }
+
+    /**
+     * // @notice Sets the owner of the contract
+     * // @param _newOwner the owner of the contract.
+     */
+    // constructor(address _newOwner) {
+    //     // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
+    //     if(_newOwner != owner()) {
+    //         transferOwnership(_newOwner);
+    //     }
+
+    //     _registerInterface(_INTERFACE_ID_ERC725X);
+    // }
+
+    /* Public functions */
+
+    /**
+     * @notice Executes any other smart contract. Is only callable by the owner.
+     *
+     *
+     * @param _operation the operation to execute: CALL = 0; DELEGATECALL = 1; CREATE2 = 2; CREATE = 3;
+     * @param _to the smart contract or address to interact with. `_to` will be unused if a contract is created (operation 2 and 3)
+     * @param _value the value of ETH to transfer
+     * @param _data the call data, or the contract data to deploy
+     */
+    function execute(uint256 _operation, address _to, uint256 _value, bytes calldata _data)
+        external
+        payable
+        override
+        onlyOwner
+    {
+        // emit event
+        emit Executed(_operation, _to, _value, _data);
+
+        uint256 txGas = gasleft() - 2500;
+
+        // CALL
+        if (_operation == OPERATION_CALL) {
+            executeCall(_to, _value, _data, txGas);
+
+        // DELEGATE CALL
+        // TODO: risky as storage slots can be overridden, remove?
+        // } else if (_operation == OPERATION_DELEGATECALL) {
+        //     address currentOwner = owner();
+        //     executeDelegateCall(_to, _data, txGas);
+        //     // Check that the owner was not overridden
+        //     require(owner() == currentOwner, "Delegate call is not allowed to modify the owner!");
+
+        // CREATE
+        } else if (_operation == OPERATION_CREATE) {
+            performCreate(_value, _data);
+
+        // CREATE2
+        } else if (_operation == OPERATION_CREATE2) {
+            bytes32 salt = BytesLib.toBytes32(_data, _data.length - 32);
+            bytes memory data = BytesLib.slice(_data, 0, _data.length - 32);
+
+            address contractAddress = Create2.deploy(_value, salt, data);
+
+            emit ContractCreated(contractAddress);
+
+        } else {
+            revert("Wrong operation type");
+        }
+    }
+
+    /* Internal functions */
+
+    // Taken from GnosisSafe
+    // https://github.com/gnosis/safe-contracts/blob/development/contracts/base/Executor.sol
+    function executeCall(address to, uint256 value, bytes memory data, uint256 txGas)
+        internal
+        returns (bool success)
+    {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := call(txGas, to, value, add(data, 0x20), mload(data), 0, 0)
+        }
+    }
+
+    // Taken from GnosisSafe
+    // https://github.com/gnosis/safe-contracts/blob/development/contracts/base/Executor.sol
+    function executeDelegateCall(address to, bytes memory data, uint256 txGas)
+        internal
+        returns (bool success)
+    {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := delegatecall(txGas, to, add(data, 0x20), mload(data), 0, 0)
+        }
+    }
+
+    // Taken from GnosisSafe
+    // https://github.com/gnosis/safe-contracts/blob/development/contracts/libraries/CreateCall.sol
+    function performCreate(uint256 value, bytes memory deploymentData)
+    internal
+    returns (address newContract)
+    {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            newContract := create(value, add(deploymentData, 0x20), mload(deploymentData))
+        }
+        require(newContract != address(0), "Could not deploy contract");
+        emit ContractCreated(newContract);
+    }
+
+    /* Modifiers */
+
+}

--- a/implementations/contracts/ERC725/ERC725YInit.sol
+++ b/implementations/contracts/ERC725/ERC725YInit.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "./IERC725Y.sol";
 
 // modules
-import "../../node_modules/@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 /**
@@ -18,16 +18,17 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
  *
  *  @author Fabian Vogelsteller <fabian@lukso.network>
  */
-contract ERC725YInit is Ownable, ERC165Storage, IERC725Y {
+contract ERC725YInit is OwnableUpgradeable, ERC165Storage, IERC725Y {
 
     bytes4 internal constant _INTERFACE_ID_ERC725Y = 0x2bd57b73;
 
     mapping(bytes32 => bytes) internal store;
 
-    function initialize(address _newOwner) virtual override public initializer {
+    function initialize(address _newOwner) virtual public initializer {
+        __Ownable_init_unchained();
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
-            Ownable.initialize(_newOwner);
+            transferOwnership(_newOwner);
         }
         
         _registerInterface(_INTERFACE_ID_ERC725Y);

--- a/implementations/contracts/ERC725/ERC725YInit.sol
+++ b/implementations/contracts/ERC725/ERC725YInit.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// interfaces
+import "./IERC725Y.sol";
+
+// modules
+import "../../node_modules/@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+/**
+ * @title ERC725 Y data store
+ * @dev Contract module which provides the ability to set arbitrary key value sets that can be changed over time.
+ * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
+ * from interfaces and other smart contracts.
+ *
+ * `setData` should only be callable by the owner of the contract set via ERC173.
+ *
+ *  @author Fabian Vogelsteller <fabian@lukso.network>
+ */
+contract ERC725YInit is Ownable, ERC165Storage, IERC725Y {
+
+    bytes4 internal constant _INTERFACE_ID_ERC725Y = 0x2bd57b73;
+
+    mapping(bytes32 => bytes) internal store;
+
+    function initialize(address _newOwner) virtual override public initializer {
+        // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
+        if (_newOwner != owner()) {
+            Ownable.initialize(_newOwner);
+        }
+        
+        _registerInterface(_INTERFACE_ID_ERC725Y);
+    }
+
+    /**
+     * // @notice Sets the owner of the contract
+     * // @param _newOwner the owner of the contract.
+     */
+    // constructor(address _newOwner) {
+    //     // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
+    //     if(_newOwner != owner()) {
+    //         transferOwnership(_newOwner);
+    //     }
+
+    //     _registerInterface(_INTERFACE_ID_ERC725Y);
+    // }
+
+    /* Public functions */
+
+    /**
+     * @notice Gets data at a given `key`
+     * @param _key the key which value to retrieve
+     * @return _value The date stored at the key
+     */
+    function getData(bytes32 _key)
+        public
+        view
+        override
+        virtual
+        returns (bytes memory _value)
+    {
+        return store[_key];
+    }
+
+    /**
+     * @notice Sets data at a given `key`
+     * @param _key the key which value to retrieve
+     * @param _value the bytes to set.
+     */
+    function setData(bytes32 _key, bytes calldata _value)
+        external
+        override
+        virtual
+        onlyOwner
+    {
+        store[_key] = _value;
+        emit DataChanged(_key, _value);
+    }
+
+
+    /* Modifiers */
+
+}

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "erc725",
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4751,6 +4751,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.0.0.tgz",
       "integrity": "sha512-UcIJl/vUVjTr3H1yYXZi7Sr2PlXzBEHVUJKOUlVyzyy0FI8oQCCy0Wx+BuK/fojdnmLeMvUk4KUvhKUybP+C7Q=="
+    },
+    "@openzeppelin/contracts-ethereum-package": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.2.3.tgz",
+      "integrity": "sha512-SPg7ac3w9E5yXITHXxhjTpDWrfYjiNJ66hqeIvygf841QPlC02oEB1F/kZFqEKl/5AvXNpSMKiBuCP13CGjChQ=="
+    },
+    "@openzeppelin/contracts-upgradeable": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.2.0.tgz",
+      "integrity": "sha512-vn0hoUqQzgOLzLZwFgh+w/D5hzJHX8F7X/7t/gZdSQYIEXMyGpXUwkr5A3eoAeoc42f/n7yDhwusvBmNknM41Q=="
     },
     "@openzeppelin/fuzzy-solidity-import-parser": {
       "version": "0.1.2",

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@openzeppelin/contracts": "^4.0.0",
-    "@openzeppelin/contracts-ethereum-package": "^2.2.3",
     "@openzeppelin/contracts-upgradeable": "^4.2.0",
     "truffle": "^5.2.5"
   },

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -19,6 +19,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@openzeppelin/contracts": "^4.0.0",
+    "@openzeppelin/contracts-ethereum-package": "^2.2.3",
+    "@openzeppelin/contracts-upgradeable": "^4.2.0",
     "truffle": "^5.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Contracts in their current state are costly to deploy (around 3 millions gas to deploy `ERC725.sol`). 
This might limit adoption of the standard. If the deployer is an address that creates an identity for itself, it would have to absorb the deployment cost.

We can reduce this cost by:

- deploying a **master contract** (=logic contract) offering the possibility to deploy the contracts via proxy.
- future identity contracts can be deployed as proxy (like [ERC1167 proxy pattern](https://weka.medium.com/how-to-send-ether-to-11-440-people-187e332566b7)).

Creating an identity will then only require to deploy a proxy that will `delegate` all calls to the master contract.

Current contracts cannot currently use these features, as they use constructors + `Ownable` pattern.

**What this PR changes in the contracts?**

- [x] Create an `Init` version of each contracts.
- [x] Change `constructors` to `initializer` functions (with `initializable` modifier)

**NB: by having one master contract, it is then also possible to [deploy the contract at a predictable address using Nick's method](https://weka.medium.com/how-to-send-ether-to-11-440-people-187e332566b7)**