### PR TITLE
Update ERC-725.md

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -173,15 +173,15 @@ interface IERC725X  /* is ERC165, ERC173 */ {
     event ContractCreated(address indexed contractAddress);
     event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes data);
 
-    function execute(uint256 operationType, address to, uint256 value, bytes memory data) public;
+    function execute(uint256 operationType, address to, uint256 value, bytes memory data) external;
 }
 
 //ERC165 identifier: `0x5a988c0f`
 interface IERC725Y /* is ERC165, ERC173 */ {
     event DataChanged(bytes32 indexed key, bytes value);
 
-    function getData(bytes32[] calldata _keys) public view returns(bytes[] memory);
-    function setData(bytes32[] calldata _keys, bytes[] calldata _values) public ;
+    function getData(bytes32[] calldata _keys) external view returns(bytes[] memory);
+    function setData(bytes32[] calldata _keys, bytes[] calldata _values) external ;
 }
 
 interface IERC725 /* is IERC725X, IERC725Y */ {

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -1,6 +1,6 @@
 ---
 eip: 725
-title: ERC-725 Smart Contract Based Account
+title: General key-value store and execution standard
 author: Fabian Vogelsteller (@frozeman), Tyler Yasaka (@tyleryasaka)
 discussions-to: https://github.com/ethereum/EIPs/issues/725
 status: Draft
@@ -22,7 +22,7 @@ groups, organisations, objects and machines.
 The standard is divided into two sub standards:
 
 `ERC725X`:
-Can execute arbitrary smart contracts using and deploy other smart contracts.
+Can execute arbitrary smart contracts and deploy other smart contracts.
 
 `ERC725Y`:
 Can hold arbitrary data through a generic key/value store.
@@ -122,8 +122,10 @@ This contract is controlled by an owner. The owner can be a smart contract or an
 This standard requires [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) and should implement the functions:
 
 - `owner() view`
-- `transferOwnership(address newOwner)`
-- and the Event `event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)`
+- `transferOwnership(address newOwner)` <br>
+
+The event:
+- `OwnershipTransferred(address indexed previousOwner, address indexed newOwner)`
 
 ### Data keys
 

--- a/implementations/contracts/ERC725/ERC725YCore.sol
+++ b/implementations/contracts/ERC725/ERC725YCore.sol
@@ -40,7 +40,7 @@ abstract contract ERC725YCore is ERC165Storage, IERC725Y {
         values = new bytes[](_keys.length);
 
         for (uint256 i=0; i < _keys.length; i++) {
-            values[i] = getData(_keys[i]);
+            values[i] = _getData(_keys[i]);
         }
 
         return values;
@@ -58,7 +58,7 @@ abstract contract ERC725YCore is ERC165Storage, IERC725Y {
     {
         require(_keys.length == _values.length, "Keys length not equal to values length");
         for (uint256 i = 0; i < _keys.length; i++) {
-            setData(_keys[i], _values[i]);
+            _setData(_keys[i], _values[i]);
         }
     }
     
@@ -69,7 +69,7 @@ abstract contract ERC725YCore is ERC165Storage, IERC725Y {
      * @param _key the key which value to retrieve
      * @return _value The data stored at the key
      */
-    function getData(bytes32 _key)
+    function _getData(bytes32 _key)
         internal
         view
         virtual
@@ -83,7 +83,7 @@ abstract contract ERC725YCore is ERC165Storage, IERC725Y {
      * @param _key the key which value to retrieve
      * @param _value the bytes to set.
      */
-    function setData(bytes32 _key, bytes calldata _value)
+    function _setData(bytes32 _key, bytes calldata _value)
         internal
         virtual
     {


### PR DESCRIPTION
- Fixing the title
- Fixing Interface Cheat Sheet
- Make the internal functions prefixed with underscore _ (as a convention).