### PR TITLE
Remove Library Linking with `internal` library function

### DIFF
--- a/implementations/contracts/Utils/ERC725Utils.sol
+++ b/implementations/contracts/Utils/ERC725Utils.sol
@@ -6,7 +6,7 @@ import "../ERC725/ERC725YInit.sol";
 
 library ERC725Utils {
     
-    function getDataSingle(IERC725Y _account, bytes32 _key) public view returns (bytes memory) {
+    function getDataSingle(IERC725Y _account, bytes32 _key) internal view returns (bytes memory) {
         bytes32[] memory keys = new bytes32[](1);
         keys[0] = _key;
         bytes memory fetchResult = _account.getData(keys)[0];


### PR DESCRIPTION
## Objective of this PR

The `ERC725Utils` declares its (unique) function as `public`.
This leads to overheads when deploying `ERC725Account`, as it requires to link the contract to the address of an already deployed ERC725Utils.

This translates as a placeholder (`__ERC725Utils___________` in truffle) within the contract bytecode, making the bytecode not deployable directly.

This PR removes library linking, by converting all calls to `getDataSingle(...)` from **external** to **internal**.

## Type

- [ ] Bug Fix
- [ ] New Feature
- [x] Performance Tweaks
- [ ] Style Tweaks
- [x] Code Refactoring
- [ ] Documentation
- [ ] Tests

## Work Done

Changing the function visibility from `public` to `internal` fixes the issue.
As stated by the Solidity docs:

> _calls to internal functions use the internal calling convention [...]._
> _To realize this in the EVM, code of internal library functions and all functions called from therein will at compile time be included in the calling contract, **and a regular JUMP call will be used instead of a DELEGATECALL.**_

## Screenshots / Output

Screenshot below shows the output of Remix, when deploying to the [LUKSO L14 test network.](https://blockscout.com/lukso/l14)

![Screenshot 2021-10-26 at 19 40 09](https://user-images.githubusercontent.com/31145285/138944244-bffc7a31-fcce-4c92-a9cf-260a2f004973.png)

Also see the absence of the library placeholder in the bytecode below.
![Screenshot 2021-10-26 at 20 02 29](https://user-images.githubusercontent.com/31145285/138944134-93460025-c4cc-4b7e-a41a-7e404ed90019.png)

## Tested

All tests passed when running `npm run tests`