### PR TITLE
Fix Interface ID header in docs

### DIFF
--- a/implementations/README.md
+++ b/implementations/README.md
@@ -55,7 +55,7 @@ npm run lint
 
 ## Technical References
 
-## Interface IDs
+### Interface IDs
 
 The table below contains a list of [ERC165]() interface IDs used by the [Solidity implementations of the ERC725 smart contracts]().
 
@@ -76,8 +76,6 @@ Despite the fact that an `ERC725Account` is an **ownable contract**, the selecto
 ^ universalReceiver    // LSP1
 ^ isValidSignature     // ERC1271
 ```
-
-`ERC725X` (`execute`), `ERC725Y` (`getData` and `setData`), `LSP1`
 
 ### Solc Contract details
 

--- a/implementations/README.md
+++ b/implementations/README.md
@@ -75,6 +75,7 @@ Despite the fact that an `ERC725Account` is an **ownable contract**, the selecto
 ^ execute              // ERC725X
 ^ universalReceiver    // LSP1
 ^ isValidSignature     // ERC1271
+= 0x63cb749b           // ERC725Account
 ```
 
 ### Solc Contract details


### PR DESCRIPTION
Just cleaned the header in the README under /implementations