### PR TITLE
feat: optimize universalReceiver function (more flexible)

### DIFF
--- a/implementations/contracts/LSP1UniversalReceiver.sol
+++ b/implementations/contracts/LSP1UniversalReceiver.sol
@@ -8,7 +8,7 @@ import "./interfaces/ILSP1UniversalReceiverDelegate.sol";
 
 // modules
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 // library
 import "./utils/ERC725Utils.sol";
@@ -27,23 +27,20 @@ abstract contract LSP1UniversalReceiver is ILSP1UniversalReceiver, Context {
         override
         returns (bytes memory returnValue)
     {
-        bytes memory receiverData = IERC725Y(erc725Y).getDataSingle(
-            _UNIVERSAL_RECEIVER_DELEGATE_KEY
-        );
-        returnValue = "";
+        bytes memory data = IERC725Y(erc725Y).getDataSingle(_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
-        // call external contract
-        if (receiverData.length == 20) {
-            address universalReceiverAddress = BytesLib.toAddress(receiverData, 0);
-
-            if (ERC165(universalReceiverAddress).supportsInterface(_INTERFACEID_LSP1_DELEGATE)) {
+        if (data.length >= 20) {
+            address universalReceiverAddress = BytesLib.toAddress(data, 0);
+            if (
+                ERC165Checker.supportsInterface(
+                    universalReceiverAddress,
+                    _INTERFACEID_LSP1_DELEGATE
+                )
+            ) {
                 returnValue = ILSP1UniversalReceiverDelegate(universalReceiverAddress)
                     .universalReceiverDelegate(_msgSender(), _typeId, _data);
             }
         }
-
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);
-
-        return returnValue;
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce ?
- Use **ERC165Checker** instead of the old method to avoid calling a non-existing function and reverting 
- Switch from checking if the length is 20 **to** checking if the length is more than 20 and taking the first 20 bytes as address

**Motivation**
- This way we can make the `universalReceiver` function more **flexible** and **functional** even if the user has set wrong data in his **UniversalProfile**
