### PR TITLE
fix: initializer re-entrancy vulnerability from OZ (4.4.1)

### DIFF
--- a/implementations/contracts/ERC725AccountInit.sol
+++ b/implementations/contracts/ERC725AccountInit.sol
@@ -15,7 +15,7 @@ contract ERC725AccountInit is ERC725Init, ERC725AccountCore {
      * @notice Sets the owner of the contract and register ERC725Account, ERC1271 and LSP1UniversalReceiver interfacesId
      * @param _newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual override(ERC725Init) initializer {
+    function initialize(address _newOwner) public virtual override(ERC725Init) onlyInitializing {
         ERC725Init.initialize(_newOwner);
         erc725Y = IERC725Y(this);
 

--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -19,7 +19,7 @@ contract ERC725Init is ERC725XInit, ERC725YInit {
         public
         virtual
         override(ERC725XInit, ERC725YInit)
-        initializer
+        onlyInitializing
     {
         ERC725XInit.initialize(_newOwner);
         ERC725YInit.initialize(_newOwner);

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -17,7 +17,7 @@ contract ERC725XInit is ERC725XCore, Initializable {
      * @notice Sets the owner of the contract and register ERC725X interfaceId
      * @param _newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual initializer {
+    function initialize(address _newOwner) public virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -17,7 +17,7 @@ contract ERC725YInit is ERC725YCore, Initializable {
      * @notice Sets the owner of the contract and register ERC725Y interfaceId
      * @param _newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual initializer {
+    function initialize(address _newOwner) public virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/smart-contracts",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.3.1",
@@ -4002,9 +4002,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
-      "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.4.1.tgz",
+      "integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -34813,9 +34813,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
-      "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.4.1.tgz",
+      "integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -36745,6 +36745,7 @@
     },
     "@zondax/filecoin-signing-tools": {
       "version": "git+ssh://git@github.com/Digital-MOB-Filecoin/filecoin-signing-tools-js.git#8f8e92157cac2556d35cab866779e9a8ea8a4e25",
+      "integrity": "sha512-u1sHMBQXGiGHv8S3LkdKs0mH1erEbD4QoHWwCZns0BuQaKlpxbdxN8ikHCQOBPT6FzSHadwhf3cTSWxVl3DGig==",
       "dev": true,
       "from": "@zondax/filecoin-signing-tools@github:Digital-MOB-Filecoin/filecoin-signing-tools-js",
       "optional": true,
@@ -55315,6 +55316,7 @@
         },
         "websocket": {
           "version": "git+ssh://git@github.com/web3-js/WebSocket-Node.git#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "integrity": "sha512-fS64f2anyRmFjuEVoqTbtgtV4Ay1dQ6kP078yM1RxnF0+9hNYk4iirrtII6FIoNoNgmhhIqzQaadEU6ZRpGoEw==",
           "dev": true,
           "from": "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis",
           "requires": {
@@ -55844,6 +55846,7 @@
         },
         "websocket": {
           "version": "git+ssh://git@github.com/web3-js/WebSocket-Node.git#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "integrity": "sha512-fS64f2anyRmFjuEVoqTbtgtV4Ay1dQ6kP078yM1RxnF0+9hNYk4iirrtII6FIoNoNgmhhIqzQaadEU6ZRpGoEw==",
           "dev": true,
           "from": "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis",
           "requires": {


### PR DESCRIPTION
# What does this PR introduce?

- [x] Fix Initializable vulnerability from OpenZeppelin, by changing modifiers from `initializer` to `onlyInitializing`