### PR TITLE
Feat/proxy version

### DIFF
--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -2,27 +2,19 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./ERC725XInit.sol";
-import "./ERC725YInit.sol";
+import "./ERC725InitAbstract.sol";
 
 /**
- * @title Proxy Implementation of ERC725 bundle
+ * @title Deployable Proxy Implementation of ERC725 bundle
  * @author Fabian Vogelsteller <fabian@lukso.network>
- * @dev Bundles ERC725X and ERC725Y together into one smart contract
+ * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract
  */
-contract ERC725Init is ERC725XInit, ERC725YInit {
+contract ERC725Init is ERC725InitAbstract {
     /**
-     * @notice Sets the owner of the contract
-     * @param _newOwner the owner of the contract
+     * @inheritdoc ERC725InitAbstract
      */
-    function initialize(address _newOwner)
-        public
-        virtual
-        override(ERC725XInit, ERC725YInit)
-        onlyInitializing
-    {
-        ERC725XInit.initialize(_newOwner);
-        ERC725YInit.initialize(_newOwner);
+    function initialize(address _newOwner) public virtual override initializer {
+        ERC725InitAbstract.initialize(_newOwner);
     }
 
     // NOTE this implementation has not by default: receive() external payable {}

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// modules
+import "./ERC725XInitAbstract.sol";
+import "./ERC725YInitAbstract.sol";
+
+/**
+ * @title Inheritable Proxy Implementation of ERC725 bundle
+ * @author Fabian Vogelsteller <fabian@lukso.network>
+ * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract
+ */
+abstract contract ERC725InitAbstract is ERC725XInitAbstract, ERC725YInitAbstract {
+    /**
+     * @notice Sets the owner of the contract
+     * @param _newOwner the owner of the contract
+     */
+    function initialize(address _newOwner)
+        public
+        virtual
+        override(ERC725XInitAbstract, ERC725YInitAbstract)
+        onlyInitializing
+    {
+        ERC725XInitAbstract.initialize(_newOwner);
+        ERC725YInitAbstract.initialize(_newOwner);
+    }
+
+    // NOTE this implementation has not by default: receive() external payable {}
+}

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -2,27 +2,20 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "./ERC725XCore.sol";
+import "./ERC725XInitAbstract.sol";
 
 /**
- * @title Proxy Implementation of ERC725 X Executor
+ * @title Deployable Proxy Implementation of ERC725 X Executor
  * @author Fabian Vogelsteller <fabian@lukso.network>
  * @dev Implementation of a contract module which provides the ability to call arbitrary functions at any other smart contract and itself,
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-contract ERC725XInit is ERC725XCore, Initializable {
+contract ERC725XInit is ERC725XInitAbstract {
     /**
-     * @notice Sets the owner of the contract and register ERC725X interfaceId
-     * @param _newOwner the owner of the contract
+     * @inheritdoc ERC725XInitAbstract
      */
-    function initialize(address _newOwner) public virtual onlyInitializing {
-        // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
-        if (_newOwner != owner()) {
-            OwnableUnset.initOwner(_newOwner);
-        }
-
-        _registerInterface(_INTERFACEID_ERC725X);
+    function initialize(address _newOwner) public virtual override initializer {
+        ERC725XInitAbstract.initialize(_newOwner);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// modules
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "./ERC725XCore.sol";
+
+/**
+ * @title Inheritable Proxy Implementation of ERC725 X Executor
+ * @author Fabian Vogelsteller <fabian@lukso.network>
+ * @dev Implementation of a contract module which provides the ability to call arbitrary functions at any other smart contract and itself,
+ * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
+ * This is the basis for a smart contract based account system, but could also be used as a proxy account system
+ */
+abstract contract ERC725XInitAbstract is ERC725XCore, Initializable {
+    /**
+     * @notice Sets the owner of the contract and register ERC725X interfaceId
+     * @param _newOwner the owner of the contract
+     */
+    function initialize(address _newOwner) public virtual onlyInitializing {
+        // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
+        if (_newOwner != owner()) {
+            OwnableUnset.initOwner(_newOwner);
+        }
+
+        _registerInterface(_INTERFACEID_ERC725X);
+    }
+}

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -2,27 +2,20 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "./ERC725YCore.sol";
+import "./ERC725YInitAbstract.sol";
 
 /**
- * @title Proxy Implementation of ERC725 Y General key/value store
+ * @title Deployable Proxy Implementation of ERC725 Y General key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network>
  * @dev Contract module which provides the ability to set arbitrary key value sets that can be changed over time
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-contract ERC725YInit is ERC725YCore, Initializable {
+contract ERC725YInit is ERC725YInitAbstract {
     /**
-     * @notice Sets the owner of the contract and register ERC725Y interfaceId
-     * @param _newOwner the owner of the contract
+     * @inheritdoc ERC725YInitAbstract
      */
-    function initialize(address _newOwner) public virtual onlyInitializing {
-        // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
-        if (_newOwner != owner()) {
-            OwnableUnset.initOwner(_newOwner);
-        }
-
-        _registerInterface(_INTERFACEID_ERC725Y);
+    function initialize(address _newOwner) public virtual override initializer {
+        ERC725YInitAbstract.initialize(_newOwner);
     }
 }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// modules
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "./ERC725YCore.sol";
+
+/**
+ * @title Inheritable Proxy Implementation of ERC725 Y General key/value store
+ * @author Fabian Vogelsteller <fabian@lukso.network>
+ * @dev Contract module which provides the ability to set arbitrary key value sets that can be changed over time
+ * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
+ * from interfaces and other smart contracts
+ */
+abstract contract ERC725YInitAbstract is ERC725YCore, Initializable {
+    /**
+     * @notice Sets the owner of the contract and register ERC725Y interfaceId
+     * @param _newOwner the owner of the contract
+     */
+    function initialize(address _newOwner) public virtual onlyInitializing {
+        // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
+        if (_newOwner != owner()) {
+            OwnableUnset.initOwner(_newOwner);
+        }
+
+        _registerInterface(_INTERFACEID_ERC725Y);
+    }
+}


### PR DESCRIPTION
## What does this PR introduce?
- This PR introduce a fix for Openzeppelin's breaking change about initializing a proxy contract. InitAbstract contracts are added to be used for inheritance, and the normal Init contracts should be used for deploying. 