### PR TITLE
ERC725 execute handle custom errors

### DIFF
--- a/implementations/constants.js
+++ b/implementations/constants.js
@@ -1,18 +1,18 @@
 const INTERFACE_ID = {
-  ERC165: "0x01ffc9a7",
-  ERC725X: "0x44c028fe",
-  ERC725Y: "0x5a988c0f",
+    ERC165: '0x01ffc9a7',
+    ERC725X: '0x44c028fe',
+    ERC725Y: '0x5a988c0f',
 };
 
 const OPERATION_TYPE = {
-  CALL: 0,
-  CREATE: 1,
-  CREATE2: 2,
-  STATICCALL: 3,
-  DELEGATECALL: 4,
+    CALL: 0,
+    CREATE: 1,
+    CREATE2: 2,
+    STATICCALL: 3,
+    DELEGATECALL: 4,
 };
 
 module.exports = {
-  INTERFACE_ID,
-  OPERATION_TYPE,
+    INTERFACE_ID,
+    OPERATION_TYPE,
 };

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -10,6 +10,7 @@ import "./interfaces/IERC725X.sol";
 // libraries
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
+import "./utils/ErrorHandlerLib.sol";
 
 // modules
 import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
@@ -103,14 +104,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165Storage, IERC725X {
         (bool success, bytes memory result) = to.call{gas: txGas, value: value}(data);
 
         if (!success) {
-            // solhint-disable reason-string
-            if (result.length < 68) revert();
-
-            // solhint-disable no-inline-assembly
-            assembly {
-                result := add(result, 0x04)
-            }
-            revert(abi.decode(result, (string)));
+            ErrorHandlerLib.revertWithParsedError(result);
         }
 
         return result;
@@ -131,13 +125,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165Storage, IERC725X {
         (bool success, bytes memory result) = to.staticcall{gas: txGas}(data);
 
         if (!success) {
-            // solhint-disable reason-string
-            if (result.length < 68) revert();
-
-            assembly {
-                result := add(result, 0x04)
-            }
-            revert(abi.decode(result, (string)));
+            ErrorHandlerLib.revertWithParsedError(result);
         }
 
         return result;
@@ -161,13 +149,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165Storage, IERC725X {
         (bool success, bytes memory result) = to.delegatecall{gas: txGas}(data);
 
         if (!success) {
-            // solhint-disable reason-string
-            if (result.length < 68) revert();
-
-            assembly {
-                result := add(result, 0x04)
-            }
-            revert(abi.decode(result, (string)));
+            ErrorHandlerLib.revertWithParsedError(result);
         }
 
         return result;

--- a/implementations/contracts/helpers/Return.sol
+++ b/implementations/contracts/helpers/Return.sol
@@ -15,8 +15,14 @@ contract ReturnTest {
         uint256 age;
     }
 
-    function functionThatRevertsWithError(string memory error) external pure {
+    error Bang();
+
+    function functionThatRevertsWithErrorString(string memory error) external pure {
         revert(error);
+    }
+
+    function functionThatRevertsWithCustomError() external pure {
+        revert Bang();
     }
 
     function returnSomeUints(uint256[] memory _arr1, uint256[] memory _arr2)

--- a/implementations/contracts/utils/ErrorHandlerLib.sol
+++ b/implementations/contracts/utils/ErrorHandlerLib.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title Error Handler
+ * @dev When calling other contracts via low-level calls like `contract.call{ ... }(data)`, errors
+ * need to be handled manually. This library will correctly handle the built-in Error(string) and
+ * Panic(uint256) as well as custom errors introduced in Solidity 0.8.4.
+ */
+library ErrorHandlerLib {
+    /**
+     * @dev Will revert with the provided error payload.
+     */
+    function revertWithParsedError(bytes memory error)
+        internal
+        pure
+        returns (string memory)
+    {
+        if (error.length > 0) {
+            // the call reverted with a error string or a custom error
+            assembly {
+                let error_size := mload(error)
+                revert(add(32, error), error_size)
+            }
+        } else {
+            // there was no error payload, revert with empty payload
+            revert();
+        }
+    }
+}

--- a/implementations/reduce-artifacts.js
+++ b/implementations/reduce-artifacts.js
@@ -11,51 +11,51 @@
  *
  * @see Github https://github.com/trufflesuite/truffle/issues/1269
  */
-const fs = require("fs");
-const TruffleConfig = require("@truffle/config");
+const fs = require('fs');
+const TruffleConfig = require('@truffle/config');
 
 // find config file & return new TruffleConfig object with config file settings (cwd)
 const truffleConfig = TruffleConfig.detect();
 const artifactsFolder = truffleConfig.contracts_build_directory;
 
 function generateSmallerArtifact(_file) {
-  fs.readFile(_file, (err, fileContent) => {
-    if (err) console.error(`Error reading file: ${err}`);
+	fs.readFile(_file, (err, fileContent) => {
+		if (err) console.error(`Error reading file: ${err}`);
 
-    let jsonArtifact = JSON.parse(fileContent);
-    removeSourcesEntries(jsonArtifact);
-    removeASTEntries(jsonArtifact);
+		let jsonArtifact = JSON.parse(fileContent);
+		removeSourcesEntries(jsonArtifact);
+		removeASTEntries(jsonArtifact);
 
-    fs.writeFile(_file, JSON.stringify(jsonArtifact), (err) => {
-      err |
-        console.log(
-          "\u2713 Smaller JSON artifact created for -> ",
-          _file.replace(artifactsFolder + "/", "")
-        );
-    });
-  });
+		fs.writeFile(_file, JSON.stringify(jsonArtifact), (err) => {
+			err |
+				console.log(
+					'\u2713 Smaller JSON artifact created for -> ',
+					_file.replace(artifactsFolder + '/', ''),
+				);
+		});
+	});
 }
 
 function removeSourcesEntries(_content) {
-  const sourceEntries = [
-    "generatedSources",
-    "deployedGeneratedSources",
-    "sourceMap",
-    "deployedSourceMap",
-    "source",
-    "sourcePath",
-  ];
-  sourceEntries.map((entry) => delete _content[entry]);
+	const sourceEntries = [
+		'generatedSources',
+		'deployedGeneratedSources',
+		'sourceMap',
+		'deployedSourceMap',
+		'source',
+		'sourcePath',
+	];
+	sourceEntries.map((entry) => delete _content[entry]);
 }
 
 function removeASTEntries(_content) {
-  const astEntries = ["ast", "legacyAST"];
-  astEntries.map((entry) => delete _content[entry]);
+	const astEntries = ['ast', 'legacyAST'];
+	astEntries.map((entry) => delete _content[entry]);
 }
 
 fs.readdir(artifactsFolder, (err, files) => {
-  if (err) console.error(`Error reading 'artifacts/' directory: ${err}`);
-  for (const file of files) {
-    generateSmallerArtifact(artifactsFolder + "/" + file);
-  }
+	if (err) console.error(`Error reading 'artifacts/' directory: ${err}`);
+	for (const file of files) {
+		generateSmallerArtifact(artifactsFolder + '/' + file);
+	}
 });

--- a/implementations/test/ERC165InterfaceIDs.test.js
+++ b/implementations/test/ERC165InterfaceIDs.test.js
@@ -1,25 +1,25 @@
-const ERC165InterfaceIDs = artifacts.require("ERC165InterfaceIDs");
+const ERC165InterfaceIDs = artifacts.require('ERC165InterfaceIDs');
 
-const { INTERFACE_ID } = require("../constants");
+const { INTERFACE_ID } = require('../constants');
 
-contract("Calculate Interface IDs", (accounts) => {
-  let contract;
+contract('Calculate Interface IDs', (accounts) => {
+	let contract;
 
-  before(async function () {
-    contract = await ERC165InterfaceIDs.new();
-  });
+	before(async function () {
+		contract = await ERC165InterfaceIDs.new();
+	});
 
-  it("ERC725X", async () => {
-    const result = await contract.getERC725XInterfaceID.call();
-    console.log("ERC725X:", result);
+	it('ERC725X', async () => {
+		const result = await contract.getERC725XInterfaceID.call();
+		console.log('ERC725X:', result);
 
-    assert.equal(result, INTERFACE_ID.ERC725X);
-  });
+		assert.equal(result, INTERFACE_ID.ERC725X);
+	});
 
-  it("ERC725Y", async () => {
-    const result = await contract.getERC725YInterfaceID.call();
-    console.log("ERC725Y:", result);
+	it('ERC725Y', async () => {
+		const result = await contract.getERC725YInterfaceID.call();
+		console.log('ERC725Y:', result);
 
-    assert.equal(result, INTERFACE_ID.ERC725Y);
-  });
+		assert.equal(result, INTERFACE_ID.ERC725Y);
+	});
 });

--- a/implementations/test/ERC725X.test.js
+++ b/implementations/test/ERC725X.test.js
@@ -1,283 +1,248 @@
-const { assert } = require("chai");
-const { BN, expectRevert } = require("openzeppelin-test-helpers");
-const { calculateCreate2 } = require("eth-create2-calculator");
+const { assert } = require('chai');
+const { BN, expectRevert } = require('openzeppelin-test-helpers');
+const { calculateCreate2 } = require('eth-create2-calculator');
 
-const AccountContract = artifacts.require("ERC725X");
+const AccountContract = artifacts.require('ERC725X');
 
-const CounterContract = artifacts.require("Counter");
-const ReturnTest = artifacts.require("ReturnTest");
-const DelegateTest = artifacts.require("DelegateTest");
+const CounterContract = artifacts.require('Counter');
+const ReturnTest = artifacts.require('ReturnTest');
+const DelegateTest = artifacts.require('DelegateTest');
 
-const { INTERFACE_ID, OPERATION_TYPE } = require("../constants");
+const { INTERFACE_ID, OPERATION_TYPE } = require('../constants');
 
-contract("ERC725X", (accounts) => {
-  let owner = accounts[0];
+contract('ERC725X', (accounts) => {
+	let owner = accounts[0];
 
-  let account;
+	let account;
 
-  before(async () => {
-    account = await AccountContract.new(owner, { from: owner });
-  });
+	before(async () => {
+		account = await AccountContract.new(owner, { from: owner });
+	});
 
-  context("Account Deployment", async () => {
-    it("Deploys correctly, and compare owners", async () => {
-      const accountOwner = await account.owner.call();
-      assert.equal(accountOwner, owner, "Addresses should match");
-    });
-  });
+	context('Account Deployment', async () => {
+		it('Deploys correctly, and compare owners', async () => {
+			const accountOwner = await account.owner.call();
+			assert.equal(accountOwner, owner, 'Addresses should match');
+		});
+	});
 
-  context("ERC165", async () => {
-    it("Supports ERC165", async () => {
-      assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC165));
-    });
-    it("Supports ERC725X", async () => {
-      assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC725X));
-    });
-  });
+	context('ERC165', async () => {
+		it('Supports ERC165', async () => {
+			assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC165));
+		});
+		it('Supports ERC725X', async () => {
+			assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC725X));
+		});
+	});
 
-  context("Testing contract functions", async () => {
-    const owner = accounts[1];
-    const newOwner = accounts[2];
-    const recipient = accounts[3];
-    let account;
+	context('Testing contract functions', async () => {
+		const owner = accounts[1];
+		const newOwner = accounts[2];
+		const recipient = accounts[3];
+		let account;
 
-    const bytecode =
-      "0x608060405234801561001057600080fd5b506040516105f93803806105f98339818101604052602081101561003357600080fd5b810190808051906020019092919050505080600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050610564806100956000396000f3fe60806040526004361061003f5760003560e01c806344c028fe1461004157806354f6127f146100fb578063749ebfb81461014a5780638da5cb5b1461018f575b005b34801561004d57600080fd5b506100f96004803603608081101561006457600080fd5b8101908080359060200190929190803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190803590602001906401000000008111156100b557600080fd5b8201836020820111156100c757600080fd5b803590602001918460018302840111640100000000831117156100e957600080fd5b90919293919293905050506101e6565b005b34801561010757600080fd5b506101346004803603602081101561011e57600080fd5b81019080803590602001909291905050506103b7565b6040518082815260200191505060405180910390f35b34801561015657600080fd5b5061018d6004803603604081101561016d57600080fd5b8101908080359060200190929190803590602001909291905050506103d3565b005b34801561019b57600080fd5b506101a46104df565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146102a9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260128152602001807f6f6e6c792d6f776e65722d616c6c6f776564000000000000000000000000000081525060200191505060405180910390fd5b600085141561030757610301848484848080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f82011690508083019250505050505050610505565b506103b0565b60018514156103aa57600061035f83838080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f8201169050808301925050505050505061051d565b90508073ffffffffffffffffffffffffffffffffffffffff167fcf78cf0d6f3d8371e1075c69c492ab4ec5d8cf23a1a239b6a51a1d00be7ca31260405160405180910390a2506103af565b600080fd5b5b5050505050565b6000806000838152602001908152602001600020549050919050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610496576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260128152602001807f6f6e6c792d6f776e65722d616c6c6f776564000000000000000000000000000081525060200191505060405180910390fd5b806000808481526020019081526020016000208190555080827f35553580e4553c909abeb5764e842ce1f93c45f9f614bde2a2ca5f5b7b7dc0fb60405160405180910390a35050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600083516020850186885af190509392505050565b60008151602083016000f0905091905056fea265627a7a723158207fb9c8d804ca4e17aec99dbd7aab0a61583b56ebcbcb7e05589f97043968644364736f6c634300051100320000000000000000000000009501234ef8368466383d698c7fe7bd5ded85b4f6";
-    const salt =
-      "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-    const data = bytecode + salt;
+		const bytecode =
+			'0x608060405234801561001057600080fd5b506040516105f93803806105f98339818101604052602081101561003357600080fd5b810190808051906020019092919050505080600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050610564806100956000396000f3fe60806040526004361061003f5760003560e01c806344c028fe1461004157806354f6127f146100fb578063749ebfb81461014a5780638da5cb5b1461018f575b005b34801561004d57600080fd5b506100f96004803603608081101561006457600080fd5b8101908080359060200190929190803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190803590602001906401000000008111156100b557600080fd5b8201836020820111156100c757600080fd5b803590602001918460018302840111640100000000831117156100e957600080fd5b90919293919293905050506101e6565b005b34801561010757600080fd5b506101346004803603602081101561011e57600080fd5b81019080803590602001909291905050506103b7565b6040518082815260200191505060405180910390f35b34801561015657600080fd5b5061018d6004803603604081101561016d57600080fd5b8101908080359060200190929190803590602001909291905050506103d3565b005b34801561019b57600080fd5b506101a46104df565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146102a9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260128152602001807f6f6e6c792d6f776e65722d616c6c6f776564000000000000000000000000000081525060200191505060405180910390fd5b600085141561030757610301848484848080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f82011690508083019250505050505050610505565b506103b0565b60018514156103aa57600061035f83838080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f8201169050808301925050505050505061051d565b90508073ffffffffffffffffffffffffffffffffffffffff167fcf78cf0d6f3d8371e1075c69c492ab4ec5d8cf23a1a239b6a51a1d00be7ca31260405160405180910390a2506103af565b600080fd5b5b5050505050565b6000806000838152602001908152602001600020549050919050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610496576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260128152602001807f6f6e6c792d6f776e65722d616c6c6f776564000000000000000000000000000081525060200191505060405180910390fd5b806000808481526020019081526020016000208190555080827f35553580e4553c909abeb5764e842ce1f93c45f9f614bde2a2ca5f5b7b7dc0fb60405160405180910390a35050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600083516020850186885af190509392505050565b60008151602083016000f0905091905056fea265627a7a723158207fb9c8d804ca4e17aec99dbd7aab0a61583b56ebcbcb7e05589f97043968644364736f6c634300051100320000000000000000000000009501234ef8368466383d698c7fe7bd5ded85b4f6';
+		const salt = 'cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+		const data = bytecode + salt;
 
-    beforeEach(async () => {
-      account = await AccountContract.new(owner, { from: owner });
-      returnTest = await ReturnTest.new({ from: owner });
-      delegateTest = await DelegateTest.new(owner, { from: owner });
-      delegateTestsecond = await DelegateTest.new(owner, { from: owner });
-    });
+		beforeEach(async () => {
+			account = await AccountContract.new(owner, { from: owner });
+			returnTest = await ReturnTest.new({ from: owner });
+			delegateTest = await DelegateTest.new(owner, { from: owner });
+			delegateTestsecond = await DelegateTest.new(owner, { from: owner });
+		});
 
-    it("Uprade ownership correctly", async () => {
-      await account.transferOwnership(newOwner, { from: owner });
-      const accountOwner = await account.owner.call();
+		it('Uprade ownership correctly', async () => {
+			await account.transferOwnership(newOwner, { from: owner });
+			const accountOwner = await account.owner.call();
 
-      assert.equal(accountOwner, newOwner, "Addresses should match");
-    });
+			assert.equal(accountOwner, newOwner, 'Addresses should match');
+		});
 
-    it("Refuse upgrades from non-onwer", async () => {
-      await expectRevert(
-        account.transferOwnership(newOwner, { from: newOwner }),
-        "Ownable: caller is not the owner"
-      );
-    });
+		it('Refuse upgrades from non-onwer', async () => {
+			await expectRevert(
+				account.transferOwnership(newOwner, { from: newOwner }),
+				'Ownable: caller is not the owner',
+			);
+		});
 
-    it("Allows owner to execute calls", async () => {
-      let initialValue, abi, secondValue;
-      counter = await CounterContract.new();
+		it('Allows owner to execute calls', async () => {
+			let initialValue, abi, secondValue;
+			counter = await CounterContract.new();
 
-      initialValue = await counter.get();
-      abi = counter.contract.methods.increment().encodeABI();
+			initialValue = await counter.get();
+			abi = counter.contract.methods.increment().encodeABI();
 
-      await account.execute(OPERATION_TYPE.CALL, counter.address, 0, abi, {
-        from: owner,
-      });
-      secondValue = await counter.get();
-      assert.isTrue(
-        new BN(initialValue).add(new BN(1)).eq(new BN(secondValue))
-      );
-    });
+			await account.execute(OPERATION_TYPE.CALL, counter.address, 0, abi, {
+				from: owner,
+			});
+			secondValue = await counter.get();
+			assert.isTrue(new BN(initialValue).add(new BN(1)).eq(new BN(secondValue)));
+		});
 
-    it("Should revert with a reason while executing a call on a revertable function", async () => {
-      abi = returnTest.contract.methods
-        .functionThatRevertsWithError("Yamen")
-        .encodeABI();
+		it('Should revert with a reason while executing a call on a revertable function', async () => {
+			abi = returnTest.contract.methods.functionThatRevertsWithError('Yamen').encodeABI();
 
-      await expectRevert(
-        account.execute(OPERATION_TYPE.CALL, returnTest.address, 0, abi, {
-          from: owner,
-        }),
-        "Yamen"
-      );
-    });
+			await expectRevert(
+				account.execute(OPERATION_TYPE.CALL, returnTest.address, 0, abi, {
+					from: owner,
+				}),
+				'Yamen',
+			);
+		});
 
-    it("Should return data when executing calls", async () => {
-      let names1 = ["Yamen", "Jean", "Fabian"];
-      let names2 = ["Yamen"];
+		it('Should return data when executing calls', async () => {
+			let names1 = ['Yamen', 'Jean', 'Fabian'];
+			let names2 = ['Yamen'];
 
-      abi = returnTest.contract.methods
-        .returnSomeStrings(names1, names2)
-        .encodeABI();
+			abi = returnTest.contract.methods.returnSomeStrings(names1, names2).encodeABI();
 
-      result = await account.execute.call(
-        OPERATION_TYPE.CALL,
-        returnTest.address,
-        0,
-        abi,
-        { from: owner }
-      );
+			result = await account.execute.call(OPERATION_TYPE.CALL, returnTest.address, 0, abi, {
+				from: owner,
+			});
 
-      let Result = web3.eth.abi.decodeParameters(
-        ["string[]", "string[]"],
-        result
-      );
-      assert.deepEqual(Result[0], names1);
-      assert.deepEqual(Result[1], names2);
-    });
+			let Result = web3.eth.abi.decodeParameters(['string[]', 'string[]'], result);
+			assert.deepEqual(Result[0], names1);
+			assert.deepEqual(Result[1], names2);
+		});
 
-    /** @todo */
-    it.skip("Should return an array of struct {Girl} and {Boy} (decoded)", async () => {
-      let boys = [{ name: "Yamen", age: 19 }];
-      let girls = [
-        { single: true, age: 54 },
-        { single: false, age: 22 },
-      ];
+		/** @todo */
+		it.skip('Should return an array of struct {Girl} and {Boy} (decoded)', async () => {
+			let boys = [{ name: 'Yamen', age: 19 }];
+			let girls = [
+				{ single: true, age: 54 },
+				{ single: false, age: 22 },
+			];
 
-      abi = returnTest.contract.methods
-        .functionThatReturnsBoysAndGirls(boys, girls)
-        .encodeABI();
+			abi = returnTest.contract.methods
+				.functionThatReturnsBoysAndGirls(boys, girls)
+				.encodeABI();
 
-      result = await account.execute.call(
-        OPERATION_TYPE.CALL,
-        returnTest.address,
-        0,
-        abi,
-        { from: owner }
-      );
+			result = await account.execute.call(OPERATION_TYPE.CALL, returnTest.address, 0, abi, {
+				from: owner,
+			});
 
-      let Result = web3.eth.abi.decodeParameters(
-        [
-          { "Boy[]": { name: "string", age: "uint256" } },
-          { "Girl[]": { single: "bool", age: "uint256" } },
-        ],
-        result
-      );
+			let Result = web3.eth.abi.decodeParameters(
+				[
+					{ 'Boy[]': { name: 'string', age: 'uint256' } },
+					{ 'Girl[]': { single: 'bool', age: 'uint256' } },
+				],
+				result,
+			);
 
-      /** @todo find a way to decode array of structs in web3.js */
-    });
+			/** @todo find a way to decode array of structs in web3.js */
+		});
 
-    it("Allows owner to execute static call and return data", async () => {
-      let nums1 = ["10", "22", "1"];
-      let nums2 = ["3"];
+		it('Allows owner to execute static call and return data', async () => {
+			let nums1 = ['10', '22', '1'];
+			let nums2 = ['3'];
 
-      abi = returnTest.contract.methods
-        .returnSomeUints(nums1, nums2)
-        .encodeABI();
+			abi = returnTest.contract.methods.returnSomeUints(nums1, nums2).encodeABI();
 
-      result = await account.execute.call(
-        OPERATION_TYPE.STATICCALL,
-        returnTest.address,
-        0,
-        abi,
-        { from: owner }
-      );
+			result = await account.execute.call(
+				OPERATION_TYPE.STATICCALL,
+				returnTest.address,
+				0,
+				abi,
+				{
+					from: owner,
+				},
+			);
 
-      let Result = web3.eth.abi.decodeParameters(
-        ["uint256[]", "uint256[]"],
-        result
-      );
-      assert.deepEqual(Result[0], nums1);
-      assert.deepEqual(Result[1], nums2);
-    });
+			let Result = web3.eth.abi.decodeParameters(['uint256[]', 'uint256[]'], result);
+			assert.deepEqual(Result[0], nums1);
+			assert.deepEqual(Result[1], nums2);
+		});
 
-    it("Should revert while executing a staticcall on a function that modify the state", async () => {
-      let abi;
-      counter = await CounterContract.new();
-      abi = counter.contract.methods.increment().encodeABI();
+		it('Should revert while executing a staticcall on a function that modify the state', async () => {
+			let abi;
+			counter = await CounterContract.new();
+			abi = counter.contract.methods.increment().encodeABI();
 
-      await expectRevert(
-        account.execute(OPERATION_TYPE.STATICCALL, counter.address, 0, abi, {
-          from: owner,
-        }),
-        "revert"
-      );
-    });
+			await expectRevert(
+				account.execute(OPERATION_TYPE.STATICCALL, counter.address, 0, abi, {
+					from: owner,
+				}),
+				'revert',
+			);
+		});
 
-    it("Should revert with a reason while executing a staticcall on a revertable function", async () => {
-      abi = returnTest.contract.methods
-        .functionThatRevertsWithError("Yamen")
-        .encodeABI();
+		it('Should revert with a reason while executing a staticcall on a revertable function', async () => {
+			abi = returnTest.contract.methods.functionThatRevertsWithError('Yamen').encodeABI();
 
-      await expectRevert(
-        account.execute(OPERATION_TYPE.STATICCALL, returnTest.address, 0, abi, {
-          from: owner,
-        }),
-        "Yamen"
-      );
-    });
+			await expectRevert(
+				account.execute(OPERATION_TYPE.STATICCALL, returnTest.address, 0, abi, {
+					from: owner,
+				}),
+				'Yamen',
+			);
+		});
 
-    it("Allows owner to execute delegatecall", async () => {
-      let abi, Value, Number;
-      Number = 3;
-      abi = delegateTestsecond.contract.methods.countChange(Number).encodeABI();
+		it('Allows owner to execute delegatecall', async () => {
+			let abi, Value, Number;
+			Number = 3;
+			abi = delegateTestsecond.contract.methods.countChange(Number).encodeABI();
 
-      await delegateTest.execute(
-        OPERATION_TYPE.DELEGATECALL,
-        delegateTestsecond.address,
-        0,
-        abi,
-        { from: owner }
-      );
+			await delegateTest.execute(
+				OPERATION_TYPE.DELEGATECALL,
+				delegateTestsecond.address,
+				0,
+				abi,
+				{
+					from: owner,
+				},
+			);
 
-      Value = await delegateTest.count();
-      assert(Value.toNumber() == Number);
-    });
+			Value = await delegateTest.count();
+			assert(Value.toNumber() == Number);
+		});
 
-    it("Allows owner to execute create", async () => {
-      let receipt = await account.execute(
-        OPERATION_TYPE.CREATE,
-        recipient,
-        0,
-        bytecode,
-        { from: owner }
-      );
+		it('Allows owner to execute create', async () => {
+			let receipt = await account.execute(OPERATION_TYPE.CREATE, recipient, 0, bytecode, {
+				from: owner,
+			});
 
-      assert.equal(receipt.logs[0].event, "ContractCreated");
-      assert.equal(receipt.logs[0].args.operation, OPERATION_TYPE.CREATE);
-      assert.equal(receipt.logs[0].args.value, "0");
-    });
+			assert.equal(receipt.logs[0].event, 'ContractCreated');
+			assert.equal(receipt.logs[0].args.operation, OPERATION_TYPE.CREATE);
+			assert.equal(receipt.logs[0].args.value, '0');
+		});
 
-    it("Should return contract address when using create1", async () => {
-      let receipt = await account.execute.call(
-        OPERATION_TYPE.CREATE,
-        recipient,
-        0,
-        bytecode,
-        { from: owner }
-      );
+		it('Should return contract address when using create1', async () => {
+			let receipt = await account.execute.call(
+				OPERATION_TYPE.CREATE,
+				recipient,
+				0,
+				bytecode,
+				{
+					from: owner,
+				},
+			);
 
-      assert(receipt != ""); // return address
-    });
+			assert(receipt != ''); // return address
+		});
 
-    it("Allows owner to execute create2", async () => {
-      let receipt = await account.execute(
-        OPERATION_TYPE.CREATE2,
-        owner,
-        0,
-        data,
-        { from: owner }
-      );
-      const precomputed = calculateCreate2(
-        account.address,
-        "0x" + salt, // deploy with added 32 bytes salt
-        bytecode
-      );
-      assert.equal(receipt.logs[0].event, "ContractCreated");
-      assert.equal(receipt.logs[0].args.operation, OPERATION_TYPE.CREATE2);
-      assert.equal(receipt.logs[0].args.contractAddress, precomputed);
-      assert.equal(receipt.logs[0].args.value, "0");
-    });
+		it('Allows owner to execute create2', async () => {
+			let receipt = await account.execute(OPERATION_TYPE.CREATE2, owner, 0, data, {
+				from: owner,
+			});
+			const precomputed = calculateCreate2(
+				account.address,
+				'0x' + salt, // deploy with added 32 bytes salt
+				bytecode,
+			);
+			assert.equal(receipt.logs[0].event, 'ContractCreated');
+			assert.equal(receipt.logs[0].args.operation, OPERATION_TYPE.CREATE2);
+			assert.equal(receipt.logs[0].args.contractAddress, precomputed);
+			assert.equal(receipt.logs[0].args.value, '0');
+		});
 
-    it("Should return contract address when using create2", async () => {
-      let receipt = await account.execute.call(
-        OPERATION_TYPE.CREATE2,
-        owner,
-        0,
-        data,
-        { from: owner }
-      );
-      const precomputed = calculateCreate2(
-        account.address,
-        "0x" + salt,
-        bytecode
-      );
-      assert(web3.utils.toChecksumAddress(receipt) == precomputed);
-    });
-  });
+		it('Should return contract address when using create2', async () => {
+			let receipt = await account.execute.call(OPERATION_TYPE.CREATE2, owner, 0, data, {
+				from: owner,
+			});
+			const precomputed = calculateCreate2(account.address, '0x' + salt, bytecode);
+			assert(web3.utils.toChecksumAddress(receipt) == precomputed);
+		});
+	});
 });

--- a/implementations/test/ERC725Y.test.js
+++ b/implementations/test/ERC725Y.test.js
@@ -1,277 +1,270 @@
-const { assert } = require("chai");
-const { expectRevert } = require("openzeppelin-test-helpers");
+const { assert } = require('chai');
+const { expectRevert } = require('openzeppelin-test-helpers');
 
-const AccountContract = artifacts.require("ERC725Y");
+const AccountContract = artifacts.require('ERC725Y');
 
-const ERC725YWriter = artifacts.require("ERC725YWriter");
-const ERC725YReader = artifacts.require("ERC725YReader");
+const ERC725YWriter = artifacts.require('ERC725YWriter');
+const ERC725YReader = artifacts.require('ERC725YReader');
 
-const { INTERFACE_ID } = require("../constants");
+const { INTERFACE_ID } = require('../constants');
 
-contract("ERC725Y", (accounts) => {
-  let owner = accounts[0];
-  let account;
+contract('ERC725Y', (accounts) => {
+	let owner = accounts[0];
+	let account;
 
-  before(async () => {
-    account = await AccountContract.new(owner, { from: owner });
-  });
+	before(async () => {
+		account = await AccountContract.new(owner, { from: owner });
+	});
 
-  context("Account Deployment", async () => {
-    it("Deploys correctly, and compare owners", async () => {
-      const account = await AccountContract.new(owner, { from: owner });
-      const accountOwner = await account.owner.call();
+	context('Account Deployment', async () => {
+		it('Deploys correctly, and compare owners', async () => {
+			const account = await AccountContract.new(owner, { from: owner });
+			const accountOwner = await account.owner.call();
 
-      assert.equal(accountOwner, owner, "Addresses should match");
-    });
-  });
+			assert.equal(accountOwner, owner, 'Addresses should match');
+		});
+	});
 
-  context("ERC165", async () => {
-    it("Supports ERC165", async () => {
-      assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC165));
-    });
+	context('ERC165', async () => {
+		it('Supports ERC165', async () => {
+			assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC165));
+		});
 
-    it("Supports ERC725Y", async () => {
-      assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC725Y));
-    });
-  });
+		it('Supports ERC725Y', async () => {
+			assert.isTrue(await account.supportsInterface.call(INTERFACE_ID.ERC725Y));
+		});
+	});
 
-  context("Interactions with Account contracts", async () => {
-    const owner = accounts[1];
-    const newOwner = accounts[2];
+	context('Interactions with Account contracts', async () => {
+		const owner = accounts[1];
+		const newOwner = accounts[2];
 
-    let account;
+		let account;
 
-    beforeEach(async () => {
-      account = await AccountContract.new(owner, { from: owner });
-    });
+		beforeEach(async () => {
+			account = await AccountContract.new(owner, { from: owner });
+		});
 
-    it("Uprade ownership correctly", async () => {
-      await account.transferOwnership(newOwner, { from: owner });
-      const accountOwner = await account.owner.call();
+		it('Uprade ownership correctly', async () => {
+			await account.transferOwnership(newOwner, { from: owner });
+			const accountOwner = await account.owner.call();
 
-      assert.equal(accountOwner, newOwner, "Addresses should match");
-    });
+			assert.equal(accountOwner, newOwner, 'Addresses should match');
+		});
 
-    it("Refuse upgrades from non-onwer", async () => {
-      await expectRevert(
-        account.transferOwnership(newOwner, { from: newOwner }),
-        "Ownable: caller is not the owner"
-      );
-    });
+		it('Refuse upgrades from non-onwer', async () => {
+			await expectRevert(
+				account.transferOwnership(newOwner, { from: newOwner }),
+				'Ownable: caller is not the owner',
+			);
+		});
 
-    it("Owner can set data", async () => {
-      const key = [web3.utils.asciiToHex("Important Data")];
-      const data = [web3.utils.asciiToHex("Important Data")];
+		it('Owner can set data', async () => {
+			const key = [web3.utils.asciiToHex('Important Data')];
+			const data = [web3.utils.asciiToHex('Important Data')];
 
-      await account.setData(key, data, { from: owner });
+			await account.setData(key, data, { from: owner });
 
-      let fetchedData = await account.getData(key);
+			let fetchedData = await account.getData(key);
 
-      assert.deepEqual(data, fetchedData);
-    });
+			assert.deepEqual(data, fetchedData);
+		});
 
-    it("Fails when non-owner sets data", async () => {
-      const key = [web3.utils.asciiToHex("Important Data")];
-      const data = [web3.utils.asciiToHex("Important Data")];
+		it('Fails when non-owner sets data', async () => {
+			const key = [web3.utils.asciiToHex('Important Data')];
+			const data = [web3.utils.asciiToHex('Important Data')];
 
-      await expectRevert(
-        account.setData(key, data, { from: newOwner }),
-        "Ownable: caller is not the owner"
-      );
-    });
-  });
+			await expectRevert(
+				account.setData(key, data, { from: newOwner }),
+				'Ownable: caller is not the owner',
+			);
+		});
+	});
 
-  context("Storage test", async () => {
-    let account;
-    let count = 1000000000;
+	context('Storage test', async () => {
+		let account;
+		let count = 1000000000;
 
-    it("Create account", async () => {
-      account = await AccountContract.new(owner, { from: owner });
-      assert.equal(await account.owner.call(), owner);
-    });
+		it('Create account', async () => {
+			account = await AccountContract.new(owner, { from: owner });
+			assert.equal(await account.owner.call(), owner);
+		});
 
-    context("Writing to storage from an EOA", async () => {
-      it("Store 32 bytes item 1", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [web3.utils.numberToHex(count++)];
-        await account.setData(key, value, { from: owner });
+		context('Writing to storage from an EOA', async () => {
+			it('Store 32 bytes item 1', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [web3.utils.numberToHex(count++)];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store 32 bytes item 2", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [web3.utils.numberToHex(count++)];
-        await account.setData(key, value, { from: owner });
+			it('Store 32 bytes item 2', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [web3.utils.numberToHex(count++)];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store 32 bytes item 3", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [web3.utils.numberToHex(count++)];
-        await account.setData(key, value, { from: owner });
+			it('Store 32 bytes item 3', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [web3.utils.numberToHex(count++)];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store 32 bytes item 4", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [web3.utils.numberToHex(count++)];
-        await account.setData(key, value, { from: owner });
+			it('Store 32 bytes item 4', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [web3.utils.numberToHex(count++)];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store a long URL as bytes item 5: https://www.google.com/url?sa=i&url=https%3A%2F%2Ftwitter.com%2Ffeindura&psig=AOvVaw21YL9Wg3jSaEXMHyITcWDe&ust=1593272505347000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCKD-guDon-oCFQAAAAAdAAAAABAD", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [
-          web3.utils.utf8ToHex(
-            "https://www.google.com/url?sa=i&url=https%3A%2F%2Ftwitter.com%2Ffeindura&psig=AOvVaw21YL9Wg3jSaEXMHyITcWDe&ust=1593272505347000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCKD-guDon-oCFQAAAAAdAAAAABAD"
-          ),
-        ];
-        await account.setData(key, value, { from: owner });
+			it('Store a long URL as bytes item 5: https://www.google.com/url?sa=i&url=https%3A%2F%2Ftwitter.com%2Ffeindura&psig=AOvVaw21YL9Wg3jSaEXMHyITcWDe&ust=1593272505347000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCKD-guDon-oCFQAAAAAdAAAAABAD', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [
+					web3.utils.utf8ToHex(
+						'https://www.google.com/url?sa=i&url=https%3A%2F%2Ftwitter.com%2Ffeindura&psig=AOvVaw21YL9Wg3jSaEXMHyITcWDe&ust=1593272505347000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCKD-guDon-oCFQAAAAAdAAAAABAD',
+					),
+				];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store 32 bytes item 6", async () => {
-        let key = [web3.utils.numberToHex(count)];
-        let value = [web3.utils.numberToHex(count)];
-        await account.setData(key, value, { from: owner });
+			it('Store 32 bytes item 6', async () => {
+				let key = [web3.utils.numberToHex(count)];
+				let value = [web3.utils.numberToHex(count)];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Update 32 bytes item 6", async () => {
-        let key = [web3.utils.numberToHex(count)];
-        let value = [web3.utils.numberToHex(count)];
-        await account.setData(key, value, { from: owner });
+			it('Update 32 bytes item 6', async () => {
+				let key = [web3.utils.numberToHex(count)];
+				let value = [web3.utils.numberToHex(count)];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store a long Paragraph as bytes", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [
-          web3.utils.utf8ToHex(
-            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-          ),
-        ];
-        await account.setData(key, value, { from: owner });
+			it('Store a long Paragraph as bytes', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [
+					web3.utils.utf8ToHex(
+						'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
+					),
+				];
+				await account.setData(key, value, { from: owner });
 
-        assert.deepEqual(await account.getData(key), value);
-      });
+				assert.deepEqual(await account.getData(key), value);
+			});
 
-      it("Store 3 items of different bytes-lengths", async () => {
-        let multipleKeys = [
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        ];
-        let multipleValues = [
-          "0xabcdef",
-          "0x0123456789abcdef",
-          "0xabcdefabcdefabcdef123456789123456789",
-        ];
-        await account.setData(multipleKeys, multipleValues, { from: owner });
+			it('Store 3 items of different bytes-lengths', async () => {
+				let multipleKeys = [
+					'0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+					'0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+					'0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+				];
+				let multipleValues = [
+					'0xabcdef',
+					'0x0123456789abcdef',
+					'0xabcdefabcdefabcdef123456789123456789',
+				];
+				await account.setData(multipleKeys, multipleValues, { from: owner });
 
-        assert.deepEqual(await account.getData(multipleKeys), multipleValues);
-      });
+				assert.deepEqual(await account.getData(multipleKeys), multipleValues);
+			});
 
-      it("Revert when Keys length is not equal to values length", async () => {
-        let multipleKeys = [
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        ];
-        let multipleValues = [
-          "0xabcdef",
-          "0x0123456789abcdef",
-          "0xabcdefabcdefabcdef123456789123456789",
-          "0xabcdefabcdefabcdef123456789123456789",
-        ];
-        await expectRevert(
-          account.setData(multipleKeys, multipleValues, { from: owner }),
-          "Keys length not equal to values length"
-        );
-      });
-    });
+			it('Revert when Keys length is not equal to values length', async () => {
+				let multipleKeys = [
+					'0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+					'0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+					'0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+				];
+				let multipleValues = [
+					'0xabcdef',
+					'0x0123456789abcdef',
+					'0xabcdefabcdefabcdef123456789123456789',
+					'0xabcdefabcdefabcdef123456789123456789',
+				];
+				await expectRevert(
+					account.setData(multipleKeys, multipleValues, { from: owner }),
+					'Keys length not equal to values length',
+				);
+			});
+		});
 
-    context("Writing to storage from a smart contract", async () => {
-      let account;
-      let erc725YWriter;
-      let erc725YReader;
+		context('Writing to storage from a smart contract', async () => {
+			let account;
+			let erc725YWriter;
+			let erc725YReader;
 
-      before(async () => {
-        erc725YWriter = await ERC725YWriter.new();
-        erc725YReader = await ERC725YReader.new();
-      });
+			before(async () => {
+				erc725YWriter = await ERC725YWriter.new();
+				erc725YReader = await ERC725YReader.new();
+			});
 
-      beforeEach(async () => {
-        account = await AccountContract.new(erc725YWriter.address, {
-          from: owner,
-        });
-        assert.equal(await account.owner.call(), erc725YWriter.address);
-      });
+			beforeEach(async () => {
+				account = await AccountContract.new(erc725YWriter.address, {
+					from: owner,
+				});
+				assert.equal(await account.owner.call(), erc725YWriter.address);
+			});
 
-      it("Should be able to setData and getData of 3 assets from Smart contracts", async () => {
-        let keys = [];
-        let values = [];
+			it('Should be able to setData and getData of 3 assets from Smart contracts', async () => {
+				let keys = [];
+				let values = [];
 
-        for (let i = 8; i <= 10; i++) {
-          keys.push(web3.utils.numberToHex(count++));
-          values.push(web3.utils.numberToHex(count + 1000));
-        }
-        await erc725YWriter.callSetData(account.address, keys, values);
+				for (let i = 8; i <= 10; i++) {
+					keys.push(web3.utils.numberToHex(count++));
+					values.push(web3.utils.numberToHex(count + 1000));
+				}
+				await erc725YWriter.callSetData(account.address, keys, values);
 
-        const result = await erc725YReader.callGetData(account.address, keys);
-        assert.deepEqual(result, values);
-      });
+				const result = await erc725YReader.callGetData(account.address, keys);
+				assert.deepEqual(result, values);
+			});
 
-      it("Should be able to setData (Array of 3 assets of different lengths) from Smart contracts", async () => {
-        let multipleKeys = [
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        ];
-        let multipleValues = [
-          "0xabcdef",
-          "0x0123456789abcdef",
-          "0xabcdefabcdefabcdef123456789123456789",
-        ];
+			it('Should be able to setData (Array of 3 assets of different lengths) from Smart contracts', async () => {
+				let multipleKeys = [
+					'0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+					'0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+					'0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+				];
+				let multipleValues = [
+					'0xabcdef',
+					'0x0123456789abcdef',
+					'0xabcdefabcdefabcdef123456789123456789',
+				];
 
-        await erc725YWriter.callSetData(
-          account.address,
-          multipleKeys,
-          multipleValues
-        );
+				await erc725YWriter.callSetData(account.address, multipleKeys, multipleValues);
 
-        let fetchedResult = await erc725YReader.callGetData(
-          account.address,
-          multipleKeys
-        );
-        assert.deepEqual(fetchedResult, multipleValues);
-      });
+				let fetchedResult = await erc725YReader.callGetData(account.address, multipleKeys);
+				assert.deepEqual(fetchedResult, multipleValues);
+			});
 
-      it("Should be able to setData and getData of 1 asset from Smart contracts", async () => {
-        let key = [web3.utils.numberToHex(count++)];
-        let value = [web3.utils.numberToHex(count + 11)];
+			it('Should be able to setData and getData of 1 asset from Smart contracts', async () => {
+				let key = [web3.utils.numberToHex(count++)];
+				let value = [web3.utils.numberToHex(count + 11)];
 
-        await erc725YWriter.callSetData(account.address, key, value);
+				await erc725YWriter.callSetData(account.address, key, value);
 
-        const result = await erc725YReader.callGetData(account.address, key);
-        assert.deepEqual(result, value);
-      });
+				const result = await erc725YReader.callGetData(account.address, key);
+				assert.deepEqual(result, value);
+			});
 
-      it("Should be able to setData (constructed) in a smart contract", async () => {
-        let key = [web3.utils.keccak256("MyName")];
-        let value = [web3.utils.utf8ToHex("LUKSO")];
+			it('Should be able to setData (constructed) in a smart contract', async () => {
+				let key = [web3.utils.keccak256('MyName')];
+				let value = [web3.utils.utf8ToHex('LUKSO')];
 
-        await erc725YWriter.setDataComputed(account.address);
-        let result = await erc725YReader.callGetData(account.address, key);
-        assert.deepEqual(result, value);
-      });
-    });
-  });
+				await erc725YWriter.setDataComputed(account.address);
+				let result = await erc725YReader.callGetData(account.address, key);
+				assert.deepEqual(result, value);
+			});
+		});
+	});
 });

--- a/implementations/test/helpers.js
+++ b/implementations/test/helpers.js
@@ -1,0 +1,23 @@
+// A version of expectRevert, that can handle custom errors
+//
+// Can be removed once this issue is fixed
+// https://github.com/OpenZeppelin/openzeppelin-test-helpers/issues/180
+async function expectRevertWithCustomError(promise, expectedError) {
+    try {
+        await promise;
+    } catch (error) {
+        // not sure what the keys are in error.data, looks like an address but its not the called
+        // contract or the EOA that signed the tx.. seems there is only one entry, so we use the
+        // first key to get the returned error
+        const errorData = error.data[Object.keys(error.data)[0]];
+        expect(errorData.return).to.equal(expectedError, 'Wrong kind of exception received');
+
+        return;
+    }
+
+    expect.fail('Expected an exception but none was received');
+}
+
+module.exports = {
+    expectRevertWithCustomError,
+};

--- a/implementations/truffle-config.js
+++ b/implementations/truffle-config.js
@@ -1,35 +1,35 @@
 module.exports = {
-  contracts_build_directory: "./artifacts",
+	contracts_build_directory: './artifacts',
 
-  // See <http://truffleframework.com/docs/advanced/configuration>
-  // to customize your Truffle configuration!
-  mocha: {
-    reporter: "eth-gas-reporter",
-    reporterOptions: {
-      currency: "USD",
-    },
-  },
+	// See <http://truffleframework.com/docs/advanced/configuration>
+	// to customize your Truffle configuration!
+	mocha: {
+		reporter: 'eth-gas-reporter',
+		reporterOptions: {
+			currency: 'USD',
+		},
+	},
 
-  // networks: {
-  //   development: {
-  //     host: "127.0.0.1",
-  //     port: 8545,
-  //     network_id: "*" // Match any network id
-  //   }
-  // },
+	// networks: {
+	//   development: {
+	//     host: "127.0.0.1",
+	//     port: 8545,
+	//     network_id: "*" // Match any network id
+	//   }
+	// },
 
-  // Configure your compilers
-  compilers: {
-    solc: {
-      version: "0.8.3", // Fetch exact version from solc-bin (default: truffle's version) //0.6.10
-      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-      // settings: {          // See the solidity docs for advice about optimization and evmVersion
-      //  optimizer: {
-      //    enabled: false,
-      //    runs: 200
-      //  },
-      //  evmVersion: "byzantium"
-      // }
-    },
-  },
+	// Configure your compilers
+	compilers: {
+		solc: {
+			version: '0.8.3', // Fetch exact version from solc-bin (default: truffle's version) //0.6.10
+			// docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+			// settings: {          // See the solidity docs for advice about optimization and evmVersion
+			//  optimizer: {
+			//    enabled: false,
+			//    runs: 200
+			//  },
+			//  evmVersion: "byzantium"
+			// }
+		},
+	},
 };

--- a/implementations/truffle-config.js
+++ b/implementations/truffle-config.js
@@ -21,7 +21,7 @@ module.exports = {
 	// Configure your compilers
 	compilers: {
 		solc: {
-			version: '0.8.3', // Fetch exact version from solc-bin (default: truffle's version) //0.6.10
+			version: '0.8.4', // Fetch exact version from solc-bin (default: truffle's version) //0.6.10
 			// docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
 			// settings: {          // See the solidity docs for advice about optimization and evmVersion
 			//  optimizer: {


### PR DESCRIPTION
# Description
With the introduction of custom errors in solc 0.8.4, the current way of handling a reverted contract call is incorrect and will not bubble all custom errors. This is due to a length check that worked for error strings, but an encoded custom error can be less than 68 bytes.

By creating a library with an internal function, this can save some code duplication in this repo, and used other contracts that may need to handle errors in a similar way (for example LSP6KeyManager).


