### PR TITLE
fix: mark `initialize(...)` as internal for `onlyInitializing` functions

### DIFF
--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -11,10 +11,11 @@ import "./ERC725InitAbstract.sol";
  */
 contract ERC725Init is ERC725InitAbstract {
     /**
-     * @inheritdoc ERC725InitAbstract
+     * @notice Sets the owner of the contract
+     * @param _newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual override initializer {
-        ERC725InitAbstract.initialize(_newOwner);
+    function initialize(address _newOwner) public virtual initializer {
+        ERC725InitAbstract._initialize(_newOwner);
     }
 
     // NOTE this implementation has not by default: receive() external payable {}

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -11,18 +11,14 @@ import "./ERC725YInitAbstract.sol";
  * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract
  */
 abstract contract ERC725InitAbstract is ERC725XInitAbstract, ERC725YInitAbstract {
-    /**
-     * @notice Sets the owner of the contract
-     * @param _newOwner the owner of the contract
-     */
-    function initialize(address _newOwner)
-        public
+    function _initialize(address _newOwner)
+        internal
         virtual
         override(ERC725XInitAbstract, ERC725YInitAbstract)
         onlyInitializing
     {
-        ERC725XInitAbstract.initialize(_newOwner);
-        ERC725YInitAbstract.initialize(_newOwner);
+        ERC725XInitAbstract._initialize(_newOwner);
+        ERC725YInitAbstract._initialize(_newOwner);
     }
 
     // NOTE this implementation has not by default: receive() external payable {}

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -13,9 +13,10 @@ import "./ERC725XInitAbstract.sol";
  */
 contract ERC725XInit is ERC725XInitAbstract {
     /**
-     * @inheritdoc ERC725XInitAbstract
+     * @notice Sets the owner of the contract and register ERC725X interfaceId
+     * @param _newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual override initializer {
-        ERC725XInitAbstract.initialize(_newOwner);
+    function initialize(address _newOwner) public virtual initializer {
+        ERC725XInitAbstract._initialize(_newOwner);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -13,11 +13,7 @@ import "./ERC725XCore.sol";
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
 abstract contract ERC725XInitAbstract is ERC725XCore, Initializable {
-    /**
-     * @notice Sets the owner of the contract and register ERC725X interfaceId
-     * @param _newOwner the owner of the contract
-     */
-    function initialize(address _newOwner) public virtual onlyInitializing {
+    function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -13,9 +13,10 @@ import "./ERC725YInitAbstract.sol";
  */
 contract ERC725YInit is ERC725YInitAbstract {
     /**
-     * @inheritdoc ERC725YInitAbstract
+     * @notice Sets the owner of the contract and register ERC725Y interfaceId
+     * @param _newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual override initializer {
-        ERC725YInitAbstract.initialize(_newOwner);
+    function initialize(address _newOwner) public virtual initializer {
+        ERC725YInitAbstract._initialize(_newOwner);
     }
 }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -13,11 +13,7 @@ import "./ERC725YCore.sol";
  * from interfaces and other smart contracts
  */
 abstract contract ERC725YInitAbstract is ERC725YCore, Initializable {
-    /**
-     * @notice Sets the owner of the contract and register ERC725Y interfaceId
-     * @param _newOwner the owner of the contract
-     */
-    function initialize(address _newOwner) public virtual onlyInitializing {
+    function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);


### PR DESCRIPTION
# What does this PR introduce?

Mark the `initialize(...)` as `internal` in the `...InitAbstract` contracts, so to avoid function overloading in contracts that inherit from them.

This remove these functions to be considered as _function overloading_ by the SOlidity compiler and to appear in the generated JSON ABI.

Also reduce size of contract bytecode as follow:
- `ERC725XInit`: - 1,394 bytes
- `ERC725YInit`: -118 bytes
- `ERC725Init`: -1,272 bytes