### PR TITLE
perf: add unchecked for iterator

### DIFF
--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -11,6 +11,9 @@ import "./interfaces/IERC725Y.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import "./utils/OwnableUnset.sol";
 
+// libraries
+import "./utils/GasLib.sol";
+
 /**
  * @title Core implementation of ERC725 Y General key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -38,7 +41,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165Storage, IERC725Y {
     {
         values = new bytes[](keys.length);
 
-        for (uint256 i = 0; i < keys.length; i++) {
+        for (uint256 i = 0; i < keys.length; i = GasLib.unchecked_inc(i)) {
             values[i] = _getData(keys[i]);
         }
 
@@ -55,7 +58,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165Storage, IERC725Y {
         onlyOwner
     {
         require(_keys.length == _values.length, "Keys length not equal to values length");
-        for (uint256 i = 0; i < _keys.length; i++) {
+        for (uint256 i = 0; i < _keys.length; i = GasLib.unchecked_inc(i)) {
             _setData(_keys[i], _values[i]);
         }
     }

--- a/implementations/contracts/utils/GasLib.sol
+++ b/implementations/contracts/utils/GasLib.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Library to add all efficient functions that could get repeated.
+ */
+library GasLib {
+    /**
+     * @dev Will return unchecked incremented uint256
+     */
+    function unchecked_inc(uint256 i) internal pure returns (uint256) {
+        unchecked {
+            return i + 1;
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR introduce?
- [x] Apply unchecked block for the iterator to cut 85 gas units per iteration.
To import the library in [lsp-smart-contract](https://github.com/lukso-network/lsp-smart-contracts) repo and apply the same pattern in the Key Manager and all other contracts needed.

The change in ERC725Y + LSP6KeyManager could save up to **~2,000** gas in an LSP7Token transfer scenario.