### PR TITLE
refactor: override `supportsInterface` instead of ERC165Storage

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -19,4 +19,22 @@ contract ERC725 is ERC725X, ERC725Y {
     constructor(address _newOwner) ERC725X(_newOwner) ERC725Y(_newOwner) {}
 
     // NOTE this implementation has not by default: receive() external payable {}
+
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725X, ERC725Y)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC725X ||
+            interfaceId == _INTERFACEID_ERC725Y ||
+            super.supportsInterface(interfaceId);
+    }
 }

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -22,4 +22,22 @@ abstract contract ERC725InitAbstract is ERC725XInitAbstract, ERC725YInitAbstract
     }
 
     // NOTE this implementation has not by default: receive() external payable {}
+
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XInitAbstract, ERC725YInitAbstract)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC725X ||
+            interfaceId == _INTERFACEID_ERC725Y ||
+            super.supportsInterface(interfaceId);
+    }
 }

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "./ERC725XCore.sol";
 
 /**
@@ -11,7 +12,7 @@ import "./ERC725XCore.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-contract ERC725X is ERC725XCore {
+contract ERC725X is ERC165, ERC725XCore {
     /**
      * @notice Sets the owner of the contract and register ERC725X interfaceId
      * @param _newOwner the owner of the contract
@@ -21,6 +22,14 @@ contract ERC725X is ERC725XCore {
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
-        _registerInterface(_INTERFACEID_ERC725X);
+    }
+
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -13,7 +13,6 @@ import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./utils/ErrorHandlerLib.sol";
 
 // modules
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import "./utils/OwnableUnset.sol";
 
 /**
@@ -23,7 +22,7 @@ import "./utils/OwnableUnset.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XCore is OwnableUnset, ERC165Storage, IERC725X {
+abstract contract ERC725XCore is OwnableUnset, IERC725X {
     /* Public functions */
 
     /**

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -22,7 +22,7 @@ import "./utils/OwnableUnset.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XCore is OwnableUnset, IERC725X {
+abstract contract ERC725XCore is IERC725X, OwnableUnset {
     /* Public functions */
 
     /**

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -13,7 +13,7 @@ import "./ERC725XCore.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XInitAbstract is ERC165, ERC725XCore, Initializable {
+abstract contract ERC725XInitAbstract is Initializable, ERC165, ERC725XCore {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // modules
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "./ERC725XCore.sol";
 
 /**
@@ -12,13 +13,20 @@ import "./ERC725XCore.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XInitAbstract is ERC725XCore, Initializable {
+abstract contract ERC725XInitAbstract is ERC165, ERC725XCore, Initializable {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
+    }
 
-        _registerInterface(_INTERFACEID_ERC725X);
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "./ERC725YCore.sol";
 
 /**
@@ -11,7 +12,7 @@ import "./ERC725YCore.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-contract ERC725Y is ERC725YCore {
+contract ERC725Y is ERC165, ERC725YCore {
     /**
      * @notice Sets the owner of the contract and register ERC725Y interfaceId
      * @param _newOwner the owner of the contract
@@ -21,7 +22,14 @@ contract ERC725Y is ERC725YCore {
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
+    }
 
-        _registerInterface(_INTERFACEID_ERC725Y);
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -20,7 +20,7 @@ import "./utils/GasLib.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-abstract contract ERC725YCore is OwnableUnset, IERC725Y {
+abstract contract ERC725YCore is IERC725Y, OwnableUnset {
     /**
      * @dev Map the keys to their values
      */

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -8,7 +8,6 @@ import "./constants.sol";
 import "./interfaces/IERC725Y.sol";
 
 // modules
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import "./utils/OwnableUnset.sol";
 
 // libraries
@@ -21,7 +20,7 @@ import "./utils/GasLib.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-abstract contract ERC725YCore is OwnableUnset, ERC165Storage, IERC725Y {
+abstract contract ERC725YCore is OwnableUnset, IERC725Y {
     /**
      * @dev Map the keys to their values
      */

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -13,7 +13,7 @@ import "./ERC725YCore.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-abstract contract ERC725YInitAbstract is ERC165, ERC725YCore, Initializable {
+abstract contract ERC725YInitAbstract is Initializable, ERC165, ERC725YCore {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // modules
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "./ERC725YCore.sol";
 
 /**
@@ -12,13 +13,20 @@ import "./ERC725YCore.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-abstract contract ERC725YInitAbstract is ERC725YCore, Initializable {
+abstract contract ERC725YInitAbstract is ERC165, ERC725YCore, Initializable {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
+    }
 
-        _registerInterface(_INTERFACEID_ERC725Y);
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- Removing the import of ERC165 from Core versions. (To not conflict when inheriting in other superior contracts).  
- Removing ERC165Storage and replacing it with overriding `supportsInterface(...)` function which reduces deployment cost by **~30,100 gas units** for each contract.
