### PR TITLE
refactor: remove importing interfaces inside `constants.sol`

### DIFF
--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// interfaces
-import "./interfaces/IERC725X.sol";
-import "./interfaces/IERC725Y.sol";
-
-// >> INTERFACES
+// >> ERC165 INTERFACE IDs
 
 // ERC725 - Smart Contract based Account
 bytes4 constant _INTERFACEID_ERC725X = 0x44c028fe;
 bytes4 constant _INTERFACEID_ERC725Y = 0x714df77c;
 
-// >> OPERATIONS
+// >> ERC725X OPERATIONS TYPES
 uint256 constant OPERATION_CALL = 0;
 uint256 constant OPERATION_CREATE = 1;
 uint256 constant OPERATION_CREATE2 = 2;

--- a/implementations/contracts/helpers/ERC165InterfaceIDs.sol
+++ b/implementations/contracts/helpers/ERC165InterfaceIDs.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import "../interfaces/IERC725X.sol";
+import "../interfaces/IERC725Y.sol";
+
 // constants
 import "../constants.sol";
 


### PR DESCRIPTION
The file `constants.sol` imports the interfaces `IERC725X` and `IERC725Y`. (previously used when interface IDs were calculated via `type(IERC725X).interfaceId`.

The `constants.sol` file should only contain constants values, and not import anything.

So moved the interfaces being imported outside of this constant file and placed them inside the helper contract `ERC165InterfaceIDs.sol` (used to ensure interface ID are correctly hardcoded as iiterals in Solidity and Javascript).