### PR TITLE
style: re-structure import statements

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./ERC725X.sol";
-import "./ERC725Y.sol";
+import {ERC725X} from "./ERC725X.sol";
+import {ERC725Y} from "./ERC725Y.sol";
+
+// constants
+import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
 
 /**
  * @title ERC725 bundle

--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./ERC725InitAbstract.sol";
+import {ERC725InitAbstract} from "./ERC725InitAbstract.sol";
 
 /**
  * @title Deployable Proxy Implementation of ERC725 bundle

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./ERC725XInitAbstract.sol";
-import "./ERC725YInitAbstract.sol";
+import {ERC725XInitAbstract} from "./ERC725XInitAbstract.sol";
+import {ERC725YInitAbstract} from "./ERC725YInitAbstract.sol";
+
+// constants
+import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725 bundle

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -2,8 +2,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "./ERC725XCore.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {OwnableUnset} from "./utils/OwnableUnset.sol";
+import {ERC725XCore} from "./ERC725XCore.sol";
+
+// constants
+import {_INTERFACEID_ERC725X} from "./constants.sol";
 
 /**
  * @title ERC725 X executor

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// constants
-import "./constants.sol";
-
 // interfaces
-import "./interfaces/IERC725X.sol";
+import {IERC725X} from "./interfaces/IERC725X.sol";
 
 // libraries
-import "@openzeppelin/contracts/utils/Create2.sol";
-import "solidity-bytes-utils/contracts/BytesLib.sol";
-import "./utils/ErrorHandlerLib.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
+import {ErrorHandlerLib} from "./utils/ErrorHandlerLib.sol";
 
 // modules
-import "./utils/OwnableUnset.sol";
+import {OwnableUnset} from "./utils/OwnableUnset.sol";
+
+// constants
+import {OPERATION_CALL, OPERATION_DELEGATECALL, OPERATION_STATICCALL, OPERATION_CREATE, OPERATION_CREATE2} from "./constants.sol";
 
 /**
  * @title Core implementation of ERC725 X executor

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./ERC725XInitAbstract.sol";
+import {ERC725XInitAbstract} from "./ERC725XInitAbstract.sol";
 
 /**
  * @title Deployable Proxy Implementation of ERC725 X Executor

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "./ERC725XCore.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {OwnableUnset} from "./utils/OwnableUnset.sol";
+import {ERC725XCore} from "./ERC725XCore.sol";
+
+// constants
+import {_INTERFACEID_ERC725X} from "./constants.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725 X Executor

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -2,8 +2,13 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "./ERC725YCore.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {OwnableUnset} from "./utils/OwnableUnset.sol";
+import {ERC725YCore} from "./ERC725YCore.sol";
+
+// constants
+import {_INTERFACEID_ERC725Y} from "./constants.sol";
 
 /**
  * @title ERC725 Y General key/value store

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// constants
-import "./constants.sol";
-
 // interfaces
-import "./interfaces/IERC725Y.sol";
-
-// modules
-import "./utils/OwnableUnset.sol";
+import {IERC725Y} from "./interfaces/IERC725Y.sol";
 
 // libraries
-import "./utils/GasLib.sol";
+import {GasLib} from "./utils/GasLib.sol";
+
+// modules
+import {OwnableUnset} from "./utils/OwnableUnset.sol";
 
 /**
  * @title Core implementation of ERC725 Y General key/value store

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./ERC725YInitAbstract.sol";
+import {ERC725YInitAbstract} from "./ERC725YInitAbstract.sol";
 
 /**
  * @title Deployable Proxy Implementation of ERC725 Y General key/value store

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "./ERC725YCore.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {OwnableUnset} from "./utils/OwnableUnset.sol";
+import {ERC725YCore} from "./ERC725YCore.sol";
+
+// constants
+import {_INTERFACEID_ERC725Y} from "./constants.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725 Y General key/value store

--- a/implementations/contracts/helpers/DelegateTest.sol
+++ b/implementations/contracts/helpers/DelegateTest.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../ERC725X.sol";
+import {ERC725X} from "../ERC725X.sol";
 
 /**
  * @dev Contract used for testing

--- a/implementations/contracts/helpers/ERC165InterfaceIDs.sol
+++ b/implementations/contracts/helpers/ERC165InterfaceIDs.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../interfaces/IERC725X.sol";
-import "../interfaces/IERC725Y.sol";
+import {IERC725X} from "../interfaces/IERC725X.sol";
+import {IERC725Y} from "../interfaces/IERC725Y.sol";
 
 // constants
-import "../constants.sol";
+import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "../constants.sol";
 
 /**
  * @dev Contract used to calculate interfacesId

--- a/implementations/contracts/helpers/ERC725YReader.sol
+++ b/implementations/contracts/helpers/ERC725YReader.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../interfaces/IERC725Y.sol";
+import {IERC725Y} from "../interfaces/IERC725Y.sol";
 
 /**
  * @dev Contract used for testing

--- a/implementations/contracts/helpers/ERC725YWriter.sol
+++ b/implementations/contracts/helpers/ERC725YWriter.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../interfaces/IERC725Y.sol";
+import {IERC725Y} from "../interfaces/IERC725Y.sol";
 
 /**
  * @dev Contract used for testing

--- a/implementations/contracts/helpers/Reader.sol
+++ b/implementations/contracts/helpers/Reader.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "../ERC725Y.sol";
+import {ERC725Y} from "../ERC725Y.sol";
 
 contract Reader {
-
     ERC725Y erc725y;
 
     constructor(ERC725Y _erc725y) {


### PR DESCRIPTION
## What does this PR introduce?
- [x] Using the `import {Module} from "File";` format for import statements
- [x] Order the layout of import statements: `interfaces` > `libraries` > `modules` > `errors` > `constants`