### PR TITLE
refactor: mark _setOwner(...) function as internal

### DIFF
--- a/implementations/contracts/utils/OwnableUnset.sol
+++ b/implementations/contracts/utils/OwnableUnset.sol
@@ -69,7 +69,7 @@ abstract contract OwnableUnset is Context {
         _setOwner(newOwner);
     }
 
-    function _setOwner(address newOwner) private {
+    function _setOwner(address newOwner) internal virtual {
         address oldOwner = _owner;
         _owner = newOwner;
         emit OwnershipTransferred(oldOwner, newOwner);


### PR DESCRIPTION
# What does this PR introduce?

Change visibility `_setOwner(...)` function `private` -> `internal`, to enable derived contract to override or implement different behaviours for transferring ownership of contracts.