### PR TITLE
refactor: use bytes4 selector in Executed event

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -13,7 +13,6 @@ import {ErrorHandlerLib} from "./utils/ErrorHandlerLib.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 
 // constants
-// constants
 // prettier-ignore
 import {
     OPERATION_CALL, 
@@ -51,14 +50,14 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
 
             result = executeCall(_to, _value, _data, txGas);
 
-            emit Executed(_operation, _to, _value, _data);
+            emit Executed(_operation, _to, _value, bytes4(_data));
 
         // STATICCALL
         } else if (_operation == OPERATION_STATICCALL) {
             
             result = executeStaticCall(_to, _data, txGas);
 
-            emit Executed(_operation, _to, _value, _data);
+            emit Executed(_operation, _to, _value, bytes4(_data));
 
         // DELEGATECALL
         } else if (_operation == OPERATION_DELEGATECALL) {
@@ -66,7 +65,7 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
             address currentOwner = owner();
             result = executeDelegateCall(_to, _data, txGas);
             
-            emit Executed(_operation, _to, _value, _data);
+            emit Executed(_operation, _to, _value, bytes4(_data));
 
             require(owner() == currentOwner, "Delegate call is not allowed to modify the owner!");
 

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -25,13 +25,13 @@ interface IERC725X {
      * @param operation The operation used to execute a contract
      * @param to The address where the call is executed
      * @param value The value sent to the created contract address
-     * @param data The data sent with the call
+     * @param selector The first 4 bytes (= function selector) of the data sent with the call
      */
     event Executed(
         uint256 indexed operation,
         address indexed to,
         uint256 indexed value,
-        bytes data
+        bytes4 selector
     );
 
     /**

--- a/implementations/truffle-config.js
+++ b/implementations/truffle-config.js
@@ -1,35 +1,35 @@
 module.exports = {
-	contracts_build_directory: './artifacts',
+  contracts_build_directory: "./artifacts",
 
-	// See <http://truffleframework.com/docs/advanced/configuration>
-	// to customize your Truffle configuration!
-	mocha: {
-		reporter: 'eth-gas-reporter',
-		reporterOptions: {
-			currency: 'USD',
-		},
-	},
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+  mocha: {
+    reporter: "eth-gas-reporter",
+    reporterOptions: {
+      currency: "USD",
+    },
+  },
 
-	// networks: {
-	//   development: {
-	//     host: "127.0.0.1",
-	//     port: 8545,
-	//     network_id: "*" // Match any network id
-	//   }
-	// },
+  // networks: {
+  //   development: {
+  //     host: "127.0.0.1",
+  //     port: 8545,
+  //     network_id: "*" // Match any network id
+  //   }
+  // },
 
-	// Configure your compilers
-	compilers: {
-		solc: {
-			version: '0.8.4', // Fetch exact version from solc-bin (default: truffle's version) //0.6.10
-			// docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-			// settings: {          // See the solidity docs for advice about optimization and evmVersion
-			//  optimizer: {
-			//    enabled: false,
-			//    runs: 200
-			//  },
-			//  evmVersion: "byzantium"
-			// }
-		},
-	},
+  // Configure your compilers
+  compilers: {
+    solc: {
+      version: "0.8.5", // Fetch exact version from solc-bin (default: truffle's version) //0.6.10
+      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+      // settings: {          // See the solidity docs for advice about optimization and evmVersion
+      //  optimizer: {
+      //    enabled: false,
+      //    runs: 200
+      //  },
+      //  evmVersion: "byzantium"
+      // }
+    },
+  },
 };


### PR DESCRIPTION
# What does this PR introduce?

Reduce gas usage in `ERC725X.execute(...)` by emitting the `Executed(...)` event with only the first 4 bytes of the `_data` payload given to the function (= function selector).

Interfaces can get more details about the function being executed by grabbing subsequent events emitted in the contract being interacted with.