### PR TITLE
fix: inherit most base to most derived

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.0;
 // modules
 import {ERC725X} from "./ERC725X.sol";
 import {ERC725Y} from "./ERC725Y.sol";
+import {ERC725XCore} from "./ERC725XCore.sol";
+import {ERC725YCore} from "./ERC725YCore.sol";
 
 // constants
 import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
@@ -32,7 +34,7 @@ contract ERC725 is ERC725X, ERC725Y {
         public
         view
         virtual
-        override(ERC725X, ERC725Y)
+        override(ERC725XCore, ERC725YCore)
         returns (bool)
     {
         return

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.0;
 // modules
 import {ERC725XInitAbstract} from "./ERC725XInitAbstract.sol";
 import {ERC725YInitAbstract} from "./ERC725YInitAbstract.sol";
+import {ERC725XCore} from "./ERC725XCore.sol";
+import {ERC725YCore} from "./ERC725YCore.sol";
 
 // constants
 import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
@@ -35,7 +37,7 @@ abstract contract ERC725InitAbstract is ERC725XInitAbstract, ERC725YInitAbstract
         public
         view
         virtual
-        override(ERC725XInitAbstract, ERC725YInitAbstract)
+        override(ERC725XCore, ERC725YCore)
         returns (bool)
     {
         return

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -6,9 +6,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
 
-// constants
-import {_INTERFACEID_ERC725X} from "./constants.sol";
-
 /**
  * @title ERC725 X executor
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -26,14 +23,5 @@ contract ERC725X is ERC725XCore {
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
-    }
-
-    /* Overrides functions */
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -16,7 +16,7 @@ import {_INTERFACEID_ERC725X} from "./constants.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-contract ERC725X is ERC165, ERC725XCore {
+contract ERC725X is ERC725XCore {
     /**
      * @notice Sets the owner of the contract and register ERC725X interfaceId
      * @param _newOwner the owner of the contract

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -10,6 +10,7 @@ import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ErrorHandlerLib} from "./utils/ErrorHandlerLib.sol";
 
 // modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 
 // constants
@@ -29,7 +30,7 @@ import {
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XCore is IERC725X, OwnableUnset {
+abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /* Public functions */
 
     /**
@@ -47,36 +48,33 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
 
         // CALL
         if (_operation == OPERATION_CALL) {
-
             result = executeCall(_to, _value, _data, txGas);
 
             emit Executed(_operation, _to, _value, bytes4(_data));
 
-        // STATICCALL
+            // STATICCALL
         } else if (_operation == OPERATION_STATICCALL) {
-            
             result = executeStaticCall(_to, _data, txGas);
 
             emit Executed(_operation, _to, _value, bytes4(_data));
 
-        // DELEGATECALL
+            // DELEGATECALL
         } else if (_operation == OPERATION_DELEGATECALL) {
-
             address currentOwner = owner();
             result = executeDelegateCall(_to, _data, txGas);
-            
+
             emit Executed(_operation, _to, _value, bytes4(_data));
 
             require(owner() == currentOwner, "Delegate call is not allowed to modify the owner!");
 
-        // CREATE
+            // CREATE
         } else if (_operation == OPERATION_CREATE) {
             address contractAddress = performCreate(_value, _data);
             result = abi.encodePacked(contractAddress);
 
             emit ContractCreated(_operation, contractAddress, _value);
 
-        // CREATE2
+            // CREATE2
         } else if (_operation == OPERATION_CREATE2) {
             bytes32 salt = BytesLib.toBytes32(_data, _data.length - 32);
             bytes memory data = BytesLib.slice(_data, 0, _data.length - 32);
@@ -85,7 +83,6 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
             result = abi.encodePacked(contractAddress);
 
             emit ContractCreated(_operation, contractAddress, _value);
-    
         } else {
             revert("Wrong operation type");
         }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725X} from "./interfaces/IERC725X.sol";
 
 // libraries
@@ -16,6 +17,7 @@ import {OwnableUnset} from "./utils/OwnableUnset.sol";
 // constants
 // prettier-ignore
 import {
+    _INTERFACEID_ERC725X,
     OPERATION_CALL, 
     OPERATION_DELEGATECALL, 
     OPERATION_STATICCALL, 
@@ -179,5 +181,20 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         }
 
         require(newContract != address(0), "Could not deploy contract");
+    }
+
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165)
+        returns (bool)
+    {
+        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -7,9 +7,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
 
-// constants
-import {_INTERFACEID_ERC725X} from "./constants.sol";
-
 /**
  * @title Inheritable Proxy Implementation of ERC725 X Executor
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -23,14 +20,5 @@ abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
-    }
-
-    /* Overrides functions */
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -17,7 +17,7 @@ import {_INTERFACEID_ERC725X} from "./constants.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XInitAbstract is Initializable, ERC165, ERC725XCore {
+abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -17,7 +17,7 @@ import {_INTERFACEID_ERC725Y} from "./constants.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-contract ERC725Y is ERC165, ERC725YCore {
+contract ERC725Y is ERC725YCore {
     /**
      * @notice Sets the owner of the contract and register ERC725Y interfaceId
      * @param _newOwner the owner of the contract

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -7,9 +7,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 import {ERC725YCore} from "./ERC725YCore.sol";
 
-// constants
-import {_INTERFACEID_ERC725Y} from "./constants.sol";
-
 /**
  * @title ERC725 Y General key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -27,14 +24,5 @@ contract ERC725Y is ERC725YCore {
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
-    }
-
-    /* Overrides functions */
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -8,6 +8,7 @@ import {IERC725Y} from "./interfaces/IERC725Y.sol";
 import {GasLib} from "./utils/GasLib.sol";
 
 // modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 
 /**
@@ -17,7 +18,7 @@ import {OwnableUnset} from "./utils/OwnableUnset.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-abstract contract ERC725YCore is IERC725Y, OwnableUnset {
+abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @dev Map the keys to their values
      */

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725Y} from "./interfaces/IERC725Y.sol";
 
 // libraries
@@ -10,6 +11,9 @@ import {GasLib} from "./utils/GasLib.sol";
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
+
+// constants
+import {_INTERFACEID_ERC725Y} from "./constants.sol";
 
 /**
  * @title Core implementation of ERC725 Y General key/value store
@@ -82,5 +86,20 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     function _setData(bytes32 key, bytes memory value) internal virtual {
         store[key] = value;
         emit DataChanged(key, value);
+    }
+
+    /* Overrides functions */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165)
+        returns (bool)
+    {
+        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 // modules
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 import {ERC725YCore} from "./ERC725YCore.sol";
 
@@ -17,7 +16,7 @@ import {_INTERFACEID_ERC725Y} from "./constants.sol";
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-abstract contract ERC725YInitAbstract is Initializable, ERC165, ERC725YCore {
+abstract contract ERC725YInitAbstract is Initializable, ERC725YCore {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -6,9 +6,6 @@ import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.s
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
 import {ERC725YCore} from "./ERC725YCore.sol";
 
-// constants
-import {_INTERFACEID_ERC725Y} from "./constants.sol";
-
 /**
  * @title Inheritable Proxy Implementation of ERC725 Y General key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -22,14 +19,5 @@ abstract contract ERC725YInitAbstract is Initializable, ERC725YCore {
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
-    }
-
-    /* Overrides functions */
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/helpers/Contract.sol
+++ b/implementations/contracts/helpers/Contract.sol
@@ -1,7 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 contract Contract {
-    
     uint256 public number;
 
     function setNumber(uint256 newNumber) public {

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 /**
  * @title The interface for ERC725X General executor
  * @dev ERC725X provides the ability to call arbitrary functions at any other smart contract and itself,
  * including using `delegatecall`, `staticcall`, as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-interface IERC725X {
+interface IERC725X is IERC165 {
     /**
      * @notice Emitted when a contract is created
      * @param operation The operation used to create a contract

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 /**
  * @title The interface for ERC725Y General key/value store
  * @dev ERC725Y provides the ability to set arbitrary key value sets that can be changed over time
  * It is intended to standardise certain keys value pairs to allow automated retrievals and interactions
  * from interfaces and other smart contracts
  */
-interface IERC725Y {
+interface IERC725Y is IERC165 {
     /**
      * @notice Emitted when data at a key is changed
      * @param key The key which value is set


### PR DESCRIPTION
## What does this PR introduce? Issue: [105](https://github.com/ERC725Alliance/ERC725/issues/105)
- Re-ordering the inherited contracts from most base to most derive
- Inherit the **IERC165** at the interface level.