### PR TITLE
fix: check for zero value with staticcall and delegatecall

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -41,12 +41,12 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
         uint256 _value,
         bytes calldata _data
     ) public payable virtual override onlyOwner returns (bytes memory result) {
-        require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
-
+        
         uint256 txGas = gasleft();
 
         // CALL
         if (_operation == OPERATION_CALL) {
+            require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
 
             result = executeCall(_to, _value, _data, txGas);
 
@@ -73,6 +73,8 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
 
         // CREATE
         } else if (_operation == OPERATION_CREATE) {
+            require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
+
             address contractAddress = performCreate(_value, _data);
             result = abi.encodePacked(contractAddress);
 
@@ -80,6 +82,8 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
 
         // CREATE2
         } else if (_operation == OPERATION_CREATE2) {
+            require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
+
             bytes32 salt = BytesLib.toBytes32(_data, _data.length - 32);
             bytes memory data = BytesLib.slice(_data, 0, _data.length - 32);
 

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -54,13 +54,15 @@ abstract contract ERC725XCore is IERC725X, OwnableUnset {
 
         // STATICCALL
         } else if (_operation == OPERATION_STATICCALL) {
-            
+            require(_value == 0, "ERC725X: cannot transfer value with operation STATICCALL");
+
             result = executeStaticCall(_to, _data, txGas);
 
             emit Executed(_operation, _to, _value, bytes4(_data));
 
         // DELEGATECALL
         } else if (_operation == OPERATION_DELEGATECALL) {
+            require(_value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
             address currentOwner = owner();
             result = executeDelegateCall(_to, _data, txGas);

--- a/implementations/test/ERC725X.test.js
+++ b/implementations/test/ERC725X.test.js
@@ -408,6 +408,18 @@ contract("ERC725X", (accounts) => {
         );
       });
 
+      it("should revert when trying to pass some `_value` in a STATICCALL", async () => {
+        await expectRevert(
+          erc725X.execute(
+            OPERATION_TYPE.STATICCALL,
+            accounts[5],
+            web3.utils.toWei("3"),
+            "0xaabbccdd"
+          ),
+          "ERC725X: cannot transfer value with operation STATICCALL"
+        );
+      });
+
       context("DELEGATECALL", async () => {
         it("should allow making a DELEGATECALL with some bytes payload to an EOA", async () => {
           const toAddress = accounts[3];
@@ -499,6 +511,18 @@ contract("ERC725X", (accounts) => {
               }
             ),
             expectedError
+          );
+        });
+
+        it("should revert when trying to pass some `_value` in a delegatecall", async () => {
+          await expectRevert(
+            erc725X.execute(
+              OPERATION_TYPE.DELEGATECALL,
+              accounts[5],
+              web3.utils.toWei("3"),
+              "0xaabbccdd"
+            ),
+            "ERC725X: cannot transfer value with operation DELEGATECALL"
           );
         });
       });


### PR DESCRIPTION
# What does this PR introduce?

The low level operations `staticcall` and `delegatecall` do not allow to pass some value.

Implement a `require(...)`  check to verify that no value is being passed in the `_value` parameter if the operation type is `STATICCALL = 3` or `DELEGATECALL = 4` 