### PR TITLE
fix!: add check to prevent delegatecall from removing initialize locks

### DIFF
--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./utils/OwnableUnset.sol";
+import {DelegateCallProxyGuard} from "./utils/DelegateCallProxyGuard.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
 
 /**
@@ -14,11 +15,21 @@ import {ERC725XCore} from "./ERC725XCore.sol";
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
-abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
+abstract contract ERC725XInitAbstract is Initializable, DelegateCallProxyGuard, ERC725XCore {
+
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         // This is necessary to prevent a contract that implements both ERC725X and ERC725Y to call both constructors
         if (_newOwner != owner()) {
             OwnableUnset.initOwner(_newOwner);
         }
+    }
+
+    function execute(
+        uint256 _operation,
+        address _to,
+        uint256 _value,
+        bytes calldata _data
+    ) public payable virtual override onlyOwner delegateCallProxyGuard(_operation) returns (bytes memory result) {
+        super.execute(_operation, _to, _value, _data);
     }
 }

--- a/implementations/contracts/helpers/ProxyBreaker.sol
+++ b/implementations/contracts/helpers/ProxyBreaker.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+contract ProxyBreaker {
+
+    function turnOffInitialised() public {
+        bytes32 slot0;
+
+        assembly {
+            slot0 := sload(0)
+        }
+
+        // unset the lowest byte corresponding to the specific offsets
+        bytes32 removeInitialised = (slot0) & ~(bytes32(uint256(1)) << 0);
+
+        assembly {
+            sstore(0, removeInitialised)
+        }
+
+    }
+
+    function turnOffInitiatedOwner() public {
+        bytes32 slot0;
+
+        assembly {
+            slot0 := sload(0)
+        }
+
+        // unset the lowest byte corresponding to the specific offset
+        bytes32 removeInitiatedOwner = (slot0) & ~(bytes32(uint256(1)) << 176);
+
+        assembly {
+            sstore(0, removeInitiatedOwner)
+        }
+
+    }
+}

--- a/implementations/contracts/utils/DelegateCallProxyGuard.sol
+++ b/implementations/contracts/utils/DelegateCallProxyGuard.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {OPERATION_DELEGATECALL} from "../constants.sol";
+
+abstract contract DelegateCallProxyGuard {
+    
+    modifier delegateCallProxyGuard(uint256 _operationType) {
+        if (_operationType == OPERATION_DELEGATECALL) {
+            
+            // do delegatecall
+            _;
+
+            bool initialisedLock;
+            bool initiatedOwnerLock;
+
+            assembly {
+                let slot0 := sload(0)
+                initialisedLock := eq(and(0x000000000000000000000000000000000000000000ff, slot0), 1)
+                initiatedOwnerLock := eq(and(0xff000000000000000000000000000000000000000000, slot0), 1)
+            }
+
+            require(initialisedLock, "ERC725XInit: Operation DELEGATECALL cannot remove the initialised lock");
+            require(initiatedOwnerLock, "ERC725XInit: Operation DELEGATECALL cannot remove the initiatedOwner lock");
+        }
+    }
+
+}

--- a/implementations/test/ERC725Init.test.js
+++ b/implementations/test/ERC725Init.test.js
@@ -1,0 +1,97 @@
+const { assert } = require("chai");
+const { web3 } = require("openzeppelin-test-helpers/src/setup");
+const { expectRevert } = require("openzeppelin-test-helpers");
+
+const ERC725Init = artifacts.require("ERC725Init");
+const ProxyBreaker = artifacts.require("ProxyBreaker");
+
+const { OPERATION_TYPE } = require("../constants");
+
+contract("ERC725Init", (accounts) => {
+  const owner = accounts[0];
+
+  let erc725Init;
+  let proxyBreaker;
+
+  before(async () => {
+    erc725Init = await ERC725Init.new({ from: owner });
+    await erc725Init.initialize(owner);
+
+    proxyBreaker = await ProxyBreaker.new();
+  });
+
+  // storage at slot 0 looks like this: 0x01cafecafecafecafecafecafecafecafecafecafe0001
+
+  // 0x01 -> initiatedOwner
+  //   cafecafecafecafecafecafecafecafecafecafe -> owner
+  //   00 -> initializing
+  //   01 -> initialised
+
+  it("should fail when ERC725X.execute(...) try to remove initialised lock via DELEGATECALL", async () => {
+    const slot = 0;
+
+    const slot0Before = await web3.eth.getStorageAt(erc725Init.address, slot);
+
+    let breakProxyPayload = proxyBreaker.contract.methods
+      .turnOffInitialised()
+      .encodeABI();
+
+    await expectRevert(
+      erc725Init.execute(
+        OPERATION_TYPE.DELEGATECALL,
+        proxyBreaker.address,
+        0,
+        breakProxyPayload
+      ),
+      "ERC725XInit: Operation DELEGATECALL cannot remove the initialised lock"
+    );
+
+    const slot0After = await web3.eth.getStorageAt(erc725Init.address, slot);
+
+    // slot0 should not have changed
+    assert.equal(slot0Before, slot0After);
+
+    const ownerAfterDelegateCall = await erc725Init.owner();
+    assert.equal(ownerAfterDelegateCall, owner);
+
+    // make sure it is not possible to re-initialise after DELEGATECALL
+    await expectRevert(
+      erc725Init.initialize(accounts[1], { from: accounts[1] }),
+      "Initializable: contract is already initialized"
+    );
+  });
+
+  it("should fail when ERC725X.execute(...) try to remove initiatedOwner lock via DELEGATECALL", async () => {
+    const slot = 0;
+
+    const slot0Before = await web3.eth.getStorageAt(erc725Init.address, slot);
+
+    let breakProxyPayload = proxyBreaker.contract.methods
+      .turnOffInitiatedOwner()
+      .encodeABI();
+
+    await expectRevert(
+      erc725Init.execute(
+        OPERATION_TYPE.DELEGATECALL,
+        proxyBreaker.address,
+        0,
+        breakProxyPayload
+      ),
+      "ERC725XInit: Operation DELEGATECALL cannot remove the initiatedOwner lock"
+    );
+
+    const slot0After = await web3.eth.getStorageAt(erc725Init.address, slot);
+
+    // slot0 should not have changed
+    assert.equal(slot0Before, slot0After);
+
+    const ownerAfterDelegateCall = await erc725Init.owner();
+    assert.equal(ownerAfterDelegateCall, owner);
+
+    // make sure it is not possible to re-initialise after DELEGATECALL
+    await expectRevert(
+      erc725Init.initialize(accounts[1], { from: accounts[1] }),
+      "Initializable: contract is already initialized"
+    );
+  });
+});

--- a/implementations/test/ERC725XInit.test.js
+++ b/implementations/test/ERC725XInit.test.js
@@ -1,0 +1,97 @@
+const { assert } = require("chai");
+const { web3 } = require("openzeppelin-test-helpers/src/setup");
+const { expectRevert } = require("openzeppelin-test-helpers");
+
+const ERC725XInit = artifacts.require("ERC725XInit");
+const ProxyBreaker = artifacts.require("ProxyBreaker");
+
+const { OPERATION_TYPE } = require("../constants");
+
+contract("ERC725XInit", (accounts) => {
+  const owner = accounts[0];
+
+  let erc725XInit;
+  let proxyBreaker;
+
+  before(async () => {
+    erc725XInit = await ERC725XInit.new({ from: owner });
+    await erc725XInit.initialize(owner);
+
+    proxyBreaker = await ProxyBreaker.new();
+  });
+
+  // storage at slot 0 looks like this: 0x01cafecafecafecafecafecafecafecafecafecafe0001
+
+  // 0x01 -> initiatedOwner
+  //   cafecafecafecafecafecafecafecafecafecafe -> owner
+  //   00 -> initializing
+  //   01 -> initialised
+
+  it("should fail when ERC725X.execute(...) try to remove initialised lock via DELEGATECALL", async () => {
+    const slot = 0;
+
+    const slot0Before = await web3.eth.getStorageAt(erc725XInit.address, slot);
+
+    let breakProxyPayload = proxyBreaker.contract.methods
+      .turnOffInitialised()
+      .encodeABI();
+
+    await expectRevert(
+      erc725XInit.execute(
+        OPERATION_TYPE.DELEGATECALL,
+        proxyBreaker.address,
+        0,
+        breakProxyPayload
+      ),
+      "ERC725XInit: Operation DELEGATECALL cannot remove the initialised lock"
+    );
+
+    const slot0After = await web3.eth.getStorageAt(erc725XInit.address, slot);
+
+    // slot0 should not have changed
+    assert.equal(slot0Before, slot0After);
+
+    const ownerAfterDelegateCall = await erc725XInit.owner();
+    assert.equal(ownerAfterDelegateCall, owner);
+
+    // make sure it is not possible to re-initialise after DELEGATECALL
+    await expectRevert(
+      erc725XInit.initialize(accounts[1], { from: accounts[1] }),
+      "Initializable: contract is already initialized"
+    );
+  });
+
+  it("should fail when ERC725X.execute(...) try to remove initiatedOwner lock via DELEGATECALL", async () => {
+    const slot = 0;
+
+    const slot0Before = await web3.eth.getStorageAt(erc725XInit.address, slot);
+
+    let breakProxyPayload = proxyBreaker.contract.methods
+      .turnOffInitiatedOwner()
+      .encodeABI();
+
+    await expectRevert(
+      erc725XInit.execute(
+        OPERATION_TYPE.DELEGATECALL,
+        proxyBreaker.address,
+        0,
+        breakProxyPayload
+      ),
+      "ERC725XInit: Operation DELEGATECALL cannot remove the initiatedOwner lock"
+    );
+
+    const slot0After = await web3.eth.getStorageAt(erc725XInit.address, slot);
+
+    // slot0 should not have changed
+    assert.equal(slot0Before, slot0After);
+
+    const ownerAfterDelegateCall = await erc725XInit.owner();
+    assert.equal(ownerAfterDelegateCall, owner);
+
+    // make sure it is not possible to re-initialise after DELEGATECALL
+    await expectRevert(
+      erc725XInit.initialize(accounts[1], { from: accounts[1] }),
+      "Initializable: contract is already initialized"
+    );
+  });
+});


### PR DESCRIPTION
# What does this PR introduce?

🔴  **Bug Fixes on Proxy / Base contract version of ERC725XInit and ERC725Init**

The Proxy versions `ERC725XInit` and `ERC725Init` introduces a **high security risk** via the `execute(...)` function.

By using the operation type DELEGTAECALL via `execute(...)`, this function introduces potential side effects on the contract state. 

## Problem


An existing check in `ERC725XCore` prevents DELEGATECALL from overriding the contract `_owner` state variable.

```solidity
} else if (_operation == OPERATION_DELEGATECALL) {

    require(_value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");

    address currentOwner = owner();
    result = executeDelegateCall(_to, _data, txGas);

    emit Executed(_operation, _to, _value, bytes4(_data));

     require(owner() == currentOwner, "Delegate call is not allowed to modify the owner!");

    // CREATE
}
```

However, **the `_owner` state variable can still be overridden** by removing the following locks in the contract storage via DELEGATECALL:

- `_initialized`: defined in the abstract contract `Initializable` from @openzeppelin.

```solidity
/**
  * @dev Indicates that the contract has been initialized.
  */
bool private _initialized;
```

- `_initiatedOwner`: defined in the custom abstract contract `OwnableUnset`

```solidity
bool private _initiatedOwner;
```

If these locks are removed, **anyone can re-call the `initialize(...)` function and become the contract owner**. 

![erc725 storage layout](https://user-images.githubusercontent.com/31145285/168549342-12b0e11e-8201-4d91-8bac-6ebad3ae70ae.jpeg)

## Solution

Introduce a modifier `delegateCallProxyGuard(operation)` that check that these locks have not been edited or removed after erc725x.execute(delegatecall, ...).
