### PR TITLE
docs: improve documentation for value transfer + contract bytecode

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -58,7 +58,7 @@ _Parameters:_
 
 - `operationType`: the operation to execute.
 - `to`: the smart contract or address to interact with. `to` will be unused if a contract is created (operation 1 and 2).
-- `value`: the amount of native tokens (in Wei) to transfer.
+- `value`: the amount of native tokens to transfer (in Wei).
 - `data`: the call data, or the contract data to deploy.
 
 _Returns:_ `bytes` , the returned data of the called function, or the address of the contract created (operation 1 and 2).
@@ -74,6 +74,8 @@ The `operationType` can be the following:
 Others may be added in the future.
 
 **Triggers Event:** [ContractCreated](#contractcreated), [Executed](#executed)
+
+> **Note:** the operations type `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
 
 ### Events
 

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -75,7 +75,7 @@ Others may be added in the future.
 
 **Triggers Event:** [ContractCreated](#contractcreated), [Executed](#executed)
 
-> **Note:** the operations type `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
+> **Note:** the operation types `staticcall` (`3`) and `delegatecall` (`4`) do not allow to transfer value.
 
 ### Events
 

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -58,7 +58,7 @@ _Parameters:_
 
 - `operationType`: the operation to execute.
 - `to`: the smart contract or address to interact with. `to` will be unused if a contract is created (operation 1 and 2).
-- `value`: the value of ETH to transfer.
+- `value`: the amount of native tokens (in Wei) to transfer.
 - `data`: the call data, or the contract data to deploy.
 
 _Returns:_ `bytes` , the returned data of the called function, or the address of the contract created (operation 1 and 2).

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -59,7 +59,7 @@ _Parameters:_
 - `operationType`: the operation to execute.
 - `to`: the smart contract or address to interact with. `to` will be unused if a contract is created (operation 1 and 2).
 - `value`: the amount of native tokens to transfer (in Wei).
-- `data`: the call data, or the contract data to deploy.
+- `data`: the call data, or the bytecode of the contract to deploy.
 
 _Returns:_ `bytes` , the returned data of the called function, or the address of the contract created (operation 1 and 2).
 

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -15,7 +15,7 @@ interface IERC725X is IERC165 {
      * @notice Emitted when a contract is created
      * @param operation The operation used to create a contract
      * @param contractAddress The created contract address
-     * @param value The value sent to the created contract address
+     * @param value The amount of native tokens (in Wei) sent to the created contract address
      */
     event ContractCreated(
         uint256 indexed operation,
@@ -27,7 +27,7 @@ interface IERC725X is IERC165 {
      * @notice Emitted when a contract executed.
      * @param operation The operation used to execute a contract
      * @param to The address where the call is executed
-     * @param value The value sent to the created contract address
+     * @param value The amount of native tokens transferred with the call (in Wei).
      * @param selector The first 4 bytes (= function selector) of the data sent with the call
      */
     event Executed(
@@ -40,8 +40,8 @@ interface IERC725X is IERC165 {
     /**
      * @param operationType The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3 DELEGATECALL = 4
      * @param to The smart contract or address to interact with, `to` will be unused if a contract is created (operation 1 and 2)
-     * @param value The value to transfer
-     * @param data The call data, or the contract data to deploy
+     * @param value The amount of native tokens to transfer (in Wei).
+     * @param data The call data, or the bytecode of the contract to deploy
      * @dev Executes any other smart contract.
      * SHOULD only be callable by the owner of the contract set via ERC173
      *


### PR DESCRIPTION
# What does this PR introduce?

Improve documentation for `ERC725X.execute(...)` with the following terms:

- replace `value` -> `amount` in docs
- specify **unit for value transfer = Wei**
- replace `ETH` -> `native tokens` to make it more generic
- [x] add note that `staticcall` and `delegatecall` do not allow value transfer.

**Other fixes**

- replaced `contract data` -> `bytecode of the contract`