### PR TITLE
refactor: check for zero address in ERC725X for operation CREATE or CREATE2

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -77,6 +77,8 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             // CREATE
         } else if (_operation == OPERATION_CREATE) {
+
+            require(to == address(0), "ERC725X: CREATE operations require the receiver address to be empty");
             require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
 
             address contractAddress = performCreate(_value, _data);
@@ -86,6 +88,8 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             // CREATE2
         } else if (_operation == OPERATION_CREATE2) {
+            
+            require(to == address(0), "ERC725X: CREATE operations require the receiver address to be empty");
             require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
 
             bytes32 salt = BytesLib.toBytes32(_data, _data.length - 32);

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -44,7 +44,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         uint256 _value,
         bytes calldata _data
     ) public payable virtual override onlyOwner returns (bytes memory result) {
-        
         uint256 txGas = gasleft();
 
         // CALL
@@ -65,7 +64,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             // DELEGATECALL
         } else if (_operation == OPERATION_DELEGATECALL) {
-
             require(_value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
             address currentOwner = owner();
@@ -77,8 +75,10 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             // CREATE
         } else if (_operation == OPERATION_CREATE) {
-
-            require(to == address(0), "ERC725X: CREATE operations require the receiver address to be empty");
+            require(
+                _to == address(0),
+                "ERC725X: CREATE operations require the receiver address to be empty"
+            );
             require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
 
             address contractAddress = performCreate(_value, _data);
@@ -88,8 +88,10 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             // CREATE2
         } else if (_operation == OPERATION_CREATE2) {
-            
-            require(to == address(0), "ERC725X: CREATE operations require the receiver address to be empty");
+            require(
+                _to == address(0),
+                "ERC725X: CREATE operations require the receiver address to be empty"
+            );
             require(address(this).balance >= _value, "ERC725X: insufficient balance for call");
 
             bytes32 salt = BytesLib.toBytes32(_data, _data.length - 32);

--- a/implementations/test/ERC725X.test.js
+++ b/implementations/test/ERC725X.test.js
@@ -572,6 +572,19 @@ contract("ERC725X", (accounts) => {
         );
       });
 
+      it("should revert when `to` is not the zero address when using CREATE", async () => {
+        await expectRevert(
+          erc725X.execute(
+            OPERATION_TYPE.CREATE,
+            accounts[5],
+            0,
+            bytecode,
+            { from: owner }
+          ),
+          "ERC725X: CREATE operations require the receiver address to be empty"
+        )
+      })
+
       it("should have emitted a ContractCreated", async () => {
         let receipt = await erc725X.execute(
           OPERATION_TYPE.CREATE,
@@ -652,6 +665,21 @@ contract("ERC725X", (accounts) => {
           web3.utils.toChecksumAddress(createdContractAddress) == precomputed
         );
       });
+
+      it("should revert when `to` is not the zero address when using CREATE2", async () => {
+        await expectRevert(
+          erc725X.execute(
+            OPERATION_TYPE.CREATE2,
+            accounts[5],
+            0,
+            data,
+            {
+              from: owner,
+            }
+          ),
+          "ERC725X: CREATE operations require the receiver address to be empty"
+        )
+      })
     });
   });
 });


### PR DESCRIPTION
# What doe this PR introduce?

## Problem

The current implementation of `execute(...)` function in `ERC725XCore` does not use the `_to` address field if the operation type is CREATE or CREATE2.

This mean that anyone can create/deploy a contract while specifying any address in the `_to` parameter (as this address will not be used).

Although this is the expected behaviour, this is semantically incorrect. The Ethereum protocol specify that for contract creation, **the `to` address field must be empty** (see [Ethereum Yellow Paper for reference](https://ethereum.github.io/yellowpaper/paper.pdf), page 4, **section 4.2) The Transaction**, bullet point **to:**).

<img width="782" alt="Screenshot 2022-05-19 at 10 18 54" src="https://user-images.githubusercontent.com/31145285/169260306-63fc9a14-530f-47c6-94c1-aa4d01f9040b.png">

## Proposed changes

Add an additional check for the `_to` parameter when `_operationType == CREATE` or `_operationType == CREATE2`, to ensure that `address(0)` is specified.