### PR TITLE
fix: replace `super` with `ERC165` in `supportsInterface`

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
 import {ERC725YCore} from "./ERC725YCore.sol";
@@ -43,6 +44,6 @@ contract ERC725 is ERC725XCore, ERC725YCore {
         return
             interfaceId == _INTERFACEID_ERC725X ||
             interfaceId == _INTERFACEID_ERC725Y ||
-            super.supportsInterface(interfaceId);
+            ERC165.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Initializable} from "./custom/Initializable.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
@@ -39,6 +40,6 @@ abstract contract ERC725InitAbstract is Initializable, ERC725XCore, ERC725YCore 
         return
             interfaceId == _INTERFACEID_ERC725X ||
             interfaceId == _INTERFACEID_ERC725Y ||
-            super.supportsInterface(interfaceId);
+            ERC165.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -211,6 +211,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         override(IERC165, ERC165)
         returns (bool)
     {
-        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_ERC725X || ERC165.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -100,6 +100,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         override(IERC165, ERC165)
         returns (bool)
     {
-        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_ERC725Y || ERC165.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- Replace `super` keyword with `ERC165` to point to the right contract to call.
Saves a few hundred gas.