### PR TITLE
refactor!: remove `owner()` check for delegatecall + add WARNING comment

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -66,12 +66,9 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         } else if (_operation == OPERATION_DELEGATECALL) {
             require(_value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
-            address currentOwner = owner();
             result = executeDelegateCall(_to, _data, txGas);
 
             emit Executed(_operation, _to, _value, bytes4(_data));
-
-            require(owner() == currentOwner, "Delegate call is not allowed to modify the owner!");
 
             // CREATE
         } else if (_operation == OPERATION_CREATE) {

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -63,22 +63,22 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
             emit Executed(_operation, _to, _value, bytes4(_data));
 
         // DELEGATECALL
+        // WARNING!
+        // delegatecall is a dangerous operation type!
+        //
+        // delegate allows to call another deployed contract and use its functions
+        // to update the state of the current calling contract
+        // 
+        // this can lead to unexpected behaviour on the contract storage, such as:
+        //
+        // - updating any state variables (even if these are protected)
+        // - update the contract owner
+        // - run selfdestruct in the context of this contract 
+        //
+        // use with EXTRA CAUTION
         } else if (_operation == OPERATION_DELEGATECALL) {
             require(_value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
-            // WARNING!
-            // delegatecall is a dangerous operation type!
-            //
-            // delegate allows to call another deployed contract and use its functions
-            // to update the state of the current calling contract
-            // 
-            // this can lead to unexpected behaviour on the contract storage, such as:
-            //
-            // - updating any state variables (even if these are protected)
-            // - update the contract owner
-            // - run selfdestruct in the context of this contract 
-            //
-            // use with EXTRA CAUTION
             result = executeDelegateCall(_to, _data, txGas);
 
             emit Executed(_operation, _to, _value, bytes4(_data));

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -54,7 +54,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             emit Executed(_operation, _to, _value, bytes4(_data));
 
-            // STATICCALL
+        // STATICCALL
         } else if (_operation == OPERATION_STATICCALL) {
             require(_value == 0, "ERC725X: cannot transfer value with operation STATICCALL");
 
@@ -62,15 +62,28 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             emit Executed(_operation, _to, _value, bytes4(_data));
 
-            // DELEGATECALL
+        // DELEGATECALL
         } else if (_operation == OPERATION_DELEGATECALL) {
             require(_value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
+            // WARNING!
+            // delegatecall is a dangerous operation type!
+            //
+            // delegate allows to call another deployed contract and use its functions
+            // to update the state of the current calling contract
+            // 
+            // this can lead to unexpected behaviour on the contract storage, such as:
+            //
+            // - updating any state variables (even if these are protected)
+            // - update the contract owner
+            // - run selfdestruct in the context of this contract 
+            //
+            // use with EXTRA CAUTION
             result = executeDelegateCall(_to, _data, txGas);
 
             emit Executed(_operation, _to, _value, bytes4(_data));
 
-            // CREATE
+        // CREATE
         } else if (_operation == OPERATION_CREATE) {
             require(
                 _to == address(0),
@@ -83,7 +96,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
             emit ContractCreated(_operation, contractAddress, _value);
 
-            // CREATE2
+        // CREATE2
         } else if (_operation == OPERATION_CREATE2) {
             require(
                 _to == address(0),


### PR DESCRIPTION
# What does this PR introduce?

## Refactor

- [x] ⚠️ remove check for `owner()` after operation type DELEGATECALL in ERC725X

## Docs

- [x] ⚠️ add **warning comment** in `ERC725XCore.sol` for operation type DELEGATECALL.