### PR TITLE
revert: (PR#116) use `super` instead of `ERC165` for `supportsInterface(..)`

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -42,6 +42,6 @@ contract ERC725 is ERC725XCore, ERC725YCore {
         return
             interfaceId == _INTERFACEID_ERC725X ||
             interfaceId == _INTERFACEID_ERC725Y ||
-            ERC165.supportsInterface(interfaceId);
+            super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -38,6 +38,6 @@ abstract contract ERC725InitAbstract is Initializable, ERC725XCore, ERC725YCore 
         return
             interfaceId == _INTERFACEID_ERC725X ||
             interfaceId == _INTERFACEID_ERC725Y ||
-            ERC165.supportsInterface(interfaceId);
+            super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -211,6 +211,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         override(IERC165, ERC165)
         returns (bool)
     {
-        return interfaceId == _INTERFACEID_ERC725X || ERC165.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -100,6 +100,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         override(IERC165, ERC165)
         returns (bool)
     {
-        return interfaceId == _INTERFACEID_ERC725Y || ERC165.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- Reverting PR #116 as it turns out that `super` is useful for contracts who inherit ERC725 contracts, not just inherited contracts by ERC725.
It is necessary to keep `super`.