### PR TITLE
refactor!: save gas on ERC725Y by removing `value` parameter in `DataChanged` event

### DIFF
--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -85,7 +85,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
 
     function _setData(bytes32 key, bytes memory value) internal virtual {
         store[key] = value;
-        emit DataChanged(key, value);
+        emit DataChanged(key);
     }
 
     /* Overrides functions */

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -14,9 +14,8 @@ interface IERC725Y is IERC165 {
     /**
      * @notice Emitted when data at a key is changed
      * @param key The key which value is set
-     * @param value The value to set
      */
-    event DataChanged(bytes32 indexed key, bytes value);
+    event DataChanged(bytes32 indexed key);
 
     /**
      * @notice Gets array of data at multiple given keys


### PR DESCRIPTION
# What does this PR introduce?

## Current Behaviour

The `DataChanged` event emits the updated value every time some data key is changed on ERC725Y.

This makes interaction with the ERC725Y key-value store expensive, especially in scenarios where:
- the `_value` contains a lot of bytes (_e.g:_ a JSONURL containing around 90 bytes).
- the caller call `setData(bytes32[],bytes[])` to update multiple data keys at once. Depending on the size of each value in the data key-value pairs, will make the call very expensive and will consume a lot of gas.


## New Behaviour

Remove the `value` parameter from the `DataChanged` event in ERC725Y.

Below is a table summary of the gas saving per bytes32 words. (**NB:** same gas savings apply, whether the data key is set for the 1st time, or updated).

| number of bytes  | gas cost `DataChanged(bytes32,bytes)` - **2 x params** | gas cost `DataChanged(bytes32)` - **1 x param** | gas saved  |
|---|---|---|---|
| 32 bytes  | 70,546  | 69,271  | **-1,275**  |
| 64 bytes  | 91,480  | 89,871  | **-1,609**  |
| 96 bytes  | 112,402  | 110,459  | **-1,943**  |
| 128 bytes  | 133,324  | 131,047  | **-2,277**  |
| 160 bytes  | 154,246  | 151,635  | **-2,611**  |