### PR TITLE
feat: add overloaded function selectors for ERC725Y

### DIFF
--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -13,3 +13,7 @@ uint256 constant OPERATION_CREATE = 1;
 uint256 constant OPERATION_CREATE2 = 2;
 uint256 constant OPERATION_STATICCALL = 3;
 uint256 constant OPERATION_DELEGATECALL = 4;
+
+// ERC725Y overloaded function selectors
+bytes4 constant SETDATA_SINGLE_SELECTOR = bytes4(keccak256("setData(bytes32,bytes)"));
+bytes4 constant SETDATA_MULTIPLE_SELECTOR = bytes4(keccak256("setData(bytes32[],bytes[])"));


### PR DESCRIPTION
## What does this PR introduce?

The syntax `Contract.function.selector` is not available in Solidity for overloaded functions.
See https://github.com/ethereum/solidity/issues/3556 for more details about the issue.

## Feat

In the Solidity constant file `constants.sol`, include the `bytes4` function selectors of the two overloaded ERC725Y functions:
- `setData(bytes32,bytes)`
- `setData(bytes32[],bytes[])`

These two selectors can then be imported individually in contracts, to adapt behaviours depending on if one or multiple data keys are being set.