### PR TITLE
style: move get / set data single function first

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -241,10 +241,11 @@ interface IERC725X  /* is ERC165, ERC173 */ {
 interface IERC725Y /* is ERC165, ERC173 */ {
     event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
-    function setData(bytes32 dataKey, bytes memory dataValue) external;
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
     function getData(bytes32 dataKey) external view returns(bytes memory);
+    function setData(bytes32 dataKey, bytes memory dataValue) external;
+
     function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory);
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
 }
 
 interface IERC725 /* is IERC725X, IERC725Y */ {

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -99,12 +99,29 @@ MUST be triggered when `execute` creates a new contract using the `operationType
 
 ERC165 identifier: `0x714df77c`
 
-**Note:** `setData()` and `getData()` uses function overloading, therefore it is better to reference them by the given function signature as follows: 
+**Note:** `setData()` and `getData()` uses function overloading, therefore it is better to reference them by the given function signature as follows:
+
 ```js
 myContract.methods['setData(bytes32[],bytes[])']([dataKeys, ...], [dataValues, ...]).send()
-// or 
+// or
 myContract.methods['0x14a6e293']([dataKeys, ...], [dataValues, ...]).send()
 ```
+
+#### getData
+
+```solidity
+function getData(bytes32 dataKey) public view returns(bytes memory)
+```
+
+Function Signature: `0x54f6127f`
+
+Gets the data set for the given dataKey.
+
+_Parameters:_
+
+- `dataKey`: the key which value to retrieve.
+
+_Returns:_ `bytes` , The data for the requested key.
 
 #### setData
 
@@ -122,37 +139,7 @@ _Parameters:_
 - `dataValue`: the data to set.
 
 **Triggers Event:** [DataChanged](#datachanged)
-#### setData (Array)
 
-```solidity
-function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public
-```
-
-Function Signature: `0x14a6e293`
-
-Sets array of data at multiple keys. MUST only be called by the current owner of the contract.
-
-_Parameters:_
-
-- `dataKeys`: the keys which values to set.
-- `dataValues`: the array of bytes to set.
-
-**Triggers Event:** [DataChanged](#datachanged)
-#### getData
-
-```solidity
-function getData(bytes32 dataKey) public view returns(bytes memory)
-```
-
-Function Signature: `0x54f6127f`
-
-Gets the data set for the given dataKey.
-
-_Parameters:_
-
-- `dataKey`: the key which value to retrieve.
-
-_Returns:_ `bytes` , The data for the requested key.
 #### getData (Array)
 
 ```solidity
@@ -169,6 +156,22 @@ _Parameters:_
 
 _Returns:_ `bytes[]` , array of the values for the requested dataKeys.
 
+#### setData (Array)
+
+```solidity
+function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public
+```
+
+Function Signature: `0x14a6e293`
+
+Sets array of data at multiple keys. MUST only be called by the current owner of the contract.
+
+_Parameters:_
+
+- `dataKeys`: the keys which values to set.
+- `dataValues`: the array of bytes to set.
+
+**Triggers Event:** [DataChanged](#datachanged)
 
 ### Events
 

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -229,7 +229,7 @@ The purpose of an smart contract account is to allow an entity to exist as a fir
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity >=0.5.0 <0.7.0;
 
-//ERC165 identifier: `0x44c028fe`
+// ERC165 identifier: `0x44c028fe`
 interface IERC725X  /* is ERC165, ERC173 */ {
     event ContractCreated(uint256 indexed operation, address indexed contractAddress, uint256 indexed value);
     event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes4 data);
@@ -237,7 +237,7 @@ interface IERC725X  /* is ERC165, ERC173 */ {
     function execute(uint256 operationType, address to, uint256 value, bytes calldata data) external payable returns(bytes memory);
 }
 
-//ERC165 identifier: `0x714df77c`
+// ERC165 identifier: `0x714df77c`
 interface IERC725Y /* is ERC165, ERC173 */ {
     event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -123,6 +123,22 @@ _Parameters:_
 
 _Returns:_ `bytes` , The data for the requested key.
 
+#### getData (Array)
+
+```solidity
+function getData(bytes32[] memory dataKeys) public view returns(bytes[] memory)
+```
+
+Function Signature: `0x4e3e6e9c`
+
+Gets array of data at multiple given key.
+
+_Parameters:_
+
+- `dataKeys`: the keys which values to retrieve.
+
+_Returns:_ `bytes[]` , array of the values for the requested dataKeys.
+
 #### setData
 
 ```solidity
@@ -139,22 +155,6 @@ _Parameters:_
 - `dataValue`: the data to set.
 
 **Triggers Event:** [DataChanged](#datachanged)
-
-#### getData (Array)
-
-```solidity
-function getData(bytes32[] memory dataKeys) public view returns(bytes[] memory)
-```
-
-Function Signature: `0x4e3e6e9c`
-
-Gets array of data at multiple given key.
-
-_Parameters:_
-
-- `dataKeys`: the keys which values to retrieve.
-
-_Returns:_ `bytes[]` , array of the values for the requested dataKeys.
 
 #### setData (Array)
 
@@ -242,9 +242,9 @@ interface IERC725Y /* is ERC165, ERC173 */ {
     event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
     function getData(bytes32 dataKey) external view returns(bytes memory);
-    function setData(bytes32 dataKey, bytes memory dataValue) external;
-
     function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory);
+
+    function setData(bytes32 dataKey, bytes memory dataValue) external;
     function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
 }
 

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -39,13 +39,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function setData(bytes32 key, bytes memory value) public virtual override onlyOwner {
-        _setData(key, value);
-    }
-
-    /**
-     * @inheritdoc IERC725Y
-     */
     function getData(bytes32[] memory keys)
         public
         view
@@ -60,6 +53,13 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         }
 
         return values;
+    }
+
+    /**
+     * @inheritdoc IERC725Y
+     */
+    function setData(bytes32 key, bytes memory value) public virtual override onlyOwner {
+        _setData(key, value);
     }
 
     /**

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -18,6 +18,23 @@ interface IERC725Y is IERC165 {
     event DataChanged(bytes32 indexed key);
 
     /**
+     * @notice Gets singular data at a given `key`
+     * @param key The key which value to retrieve
+     * @return value The data stored at the key
+     */
+    function getData(bytes32 key) external view returns (bytes memory value);
+
+    /**
+     * @notice Sets singular data at a given `key`
+     * @param key The key which value to retrieve
+     * @param value The value to set
+     * SHOULD only be callable by the owner of the contract set via ERC173
+     *
+     * Emits a {DataChanged} event.
+     */
+    function setData(bytes32 key, bytes memory value) external;
+
+    /**
      * @notice Gets array of data at multiple given keys
      * @param keys The array of keys which values to retrieve
      * @return values The array of data stored at multiple keys
@@ -34,20 +51,5 @@ interface IERC725Y is IERC165 {
      */
     function setData(bytes32[] memory keys, bytes[] memory values) external;
 
-    /**
-     * @notice Gets singular data at a given `key`
-     * @param key The key which value to retrieve
-     * @return value The data stored at the key
-     */
-    function getData(bytes32 key) external view returns (bytes memory value);
-
-    /**
-     * @notice Sets singular data at a given `key`
-     * @param key The key which value to retrieve
-     * @param value The value to set
-     * SHOULD only be callable by the owner of the contract set via ERC173
-     *
-     * Emits a {DataChanged} event.
-     */
-    function setData(bytes32 key, bytes memory value) external;
+    
 }

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -25,6 +25,13 @@ interface IERC725Y is IERC165 {
     function getData(bytes32 key) external view returns (bytes memory value);
 
     /**
+     * @notice Gets array of data at multiple given keys
+     * @param keys The array of keys which values to retrieve
+     * @return values The array of data stored at multiple keys
+     */
+    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
+
+    /**
      * @notice Sets singular data at a given `key`
      * @param key The key which value to retrieve
      * @param value The value to set
@@ -33,13 +40,6 @@ interface IERC725Y is IERC165 {
      * Emits a {DataChanged} event.
      */
     function setData(bytes32 key, bytes memory value) external;
-
-    /**
-     * @notice Gets array of data at multiple given keys
-     * @param keys The array of keys which values to retrieve
-     * @return values The array of data stored at multiple keys
-     */
-    function getData(bytes32[] memory keys) external view returns (bytes[] memory values);
 
     /**
      * @param keys The array of keys which values to set


### PR DESCRIPTION
# What does this PR introduce?

> Changes in this file a more visible by looking at the files themselves, rather than the diff
> https://github.com/ERC725Alliance/ERC725/blob/style/erc725y/implementations/contracts/interfaces/IERC725Y.sol
> https://github.com/ERC725Alliance/ERC725/blob/style/erc725y/docs/ERC-725.md#erc725y

- change order of the definitions for ERC725Y functions to read/write data key(s).

1. functions to read/write a single data key defined **first**
2. functions to read/write multiple data key defined **second**

As per the following order:

```
getData(bytes32)
setData(bytes32,bytes)

getData(bytes32[])
setData(bytes32[],bytes[])
```

## Style

- [x] Edit order in `IERC725Y.sol` interface contracts


## Docs

- [x] Edit order in **methods** section in `docs/ERC725.md`
- [x] Edit order in **interface cheat sheet** section in `docs/ERC725.md`
- [x] add extra space between comment `//` and `ERC165 interface ID` in **interface cheat sheet** section