### PR TITLE
chore(release): prepare release of 3.1.1

### DIFF
--- a/implementations/CHANGELOG.md
+++ b/implementations/CHANGELOG.md
@@ -4,17 +4,17 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [3.1.1](https://github.com/ERC725Alliance/ERC725/compare/v3.1.0...v3.1.1) (2022-06-07)
 
+This minor release simply include the two `bytes4` function selectors of the overloaded functions `setData(bytes32,bytes)` and `setData(bytes32[],bytes[])` in the `constants.sol` file.
+
+- add overloaded function selectors of ERC725Y in `constants.sol` ([#126](https://github.com/ERC725Alliance/ERC725/issues/126)) ([a4e6b52](https://github.com/ERC725Alliance/ERC725/commit/a4e6b52f58a9abc781841017b963f31e99624e83))
 
 ### ⚠ BREAKING CHANGES
 
-* remove `value` param in `DataChanged` event (#123)
+- remove `value` param in `DataChanged` event (#123)
 
 ### Features
 
-* add overloaded function selectors of ERC725Y in `constants.sol` ([#126](https://github.com/ERC725Alliance/ERC725/issues/126)) ([a4e6b52](https://github.com/ERC725Alliance/ERC725/commit/a4e6b52f58a9abc781841017b963f31e99624e83))
-
-
-* remove `value` param in `DataChanged` event ([#123](https://github.com/ERC725Alliance/ERC725/issues/123)) ([8794d16](https://github.com/ERC725Alliance/ERC725/commit/8794d16033fbfc97d3d26808fdcc6602abd4a6da))
+- remove `value` param in `DataChanged` event ([#123](https://github.com/ERC725Alliance/ERC725/issues/123)) ([8794d16](https://github.com/ERC725Alliance/ERC725/commit/8794d16033fbfc97d3d26808fdcc6602abd4a6da))
 
 ## [3.1.0](https://github.com/ERC725Alliance/ERC725/compare/v3.0.3...v3.1.0) (2022-06-07)
 

--- a/implementations/CHANGELOG.md
+++ b/implementations/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.1.1](https://github.com/ERC725Alliance/ERC725/compare/v3.1.0...v3.1.1) (2022-06-07)
+
+
+### ⚠ BREAKING CHANGES
+
+* remove `value` param in `DataChanged` event (#123)
+
+### Features
+
+* add overloaded function selectors of ERC725Y in `constants.sol` ([#126](https://github.com/ERC725Alliance/ERC725/issues/126)) ([a4e6b52](https://github.com/ERC725Alliance/ERC725/commit/a4e6b52f58a9abc781841017b963f31e99624e83))
+
+
+* remove `value` param in `DataChanged` event ([#123](https://github.com/ERC725Alliance/ERC725/issues/123)) ([8794d16](https://github.com/ERC725Alliance/ERC725/commit/8794d16033fbfc97d3d26808fdcc6602abd4a6da))
+
+## [3.1.0](https://github.com/ERC725Alliance/ERC725/compare/v3.0.3...v3.1.0) (2022-06-07)
+
+### ⚠ BREAKING CHANGES
+
+- remove `value` param in `DataChanged` event (#123)
+
+### Features
+
+- add overloaded function selectors of ERC725Y in `constants.sol` ([#126](https://github.com/ERC725Alliance/ERC725/issues/126)) ([a4e6b52](https://github.com/ERC725Alliance/ERC725/commit/a4e6b52f58a9abc781841017b963f31e99624e83))
+
+- remove `value` param in `DataChanged` event ([#123](https://github.com/ERC725Alliance/ERC725/issues/123)) ([8794d16](https://github.com/ERC725Alliance/ERC725/commit/8794d16033fbfc97d3d26808fdcc6602abd4a6da))
+
 ## [3.0.3](https://www.npmjs.com/package/@erc725/smart-contracts/v/3.0.3) (2022-05-25)
 
 - `ERC725X`: removed `owner()` check for operation delegatecall ([#119](https://github.com/ERC725Alliance/ERC725/pull/119))

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "3.0.3",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/smart-contracts",
-      "version": "3.0.3",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.6.0",

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "ERC725 contract implementations",
   "homepage": "https://erc725alliance.org",
   "repository": {
@@ -27,7 +27,7 @@
     "test": "truffle test",
     "test:coverage": "truffle run coverage",
     "solc": "sh solc.sh",
-    "release": "truffle compile --all; npm run test; npm run package; npm publish",
+    "release": "truffle compile --all; npm run package && standard-version",
     "package": "node reduce-artifacts.js"
   },
   "author": "Fabian Vogelsteller <fabian@lukso.network>",
@@ -47,8 +47,8 @@
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "solc": "^0.4.26",
     "solhint": "^3.3.6",
-    "standard-version": "^9.5.0",
     "solidity-coverage": "^0.7.20",
+    "standard-version": "^9.3.1",
     "truffle": "^5.2.5"
   },
   "prettier": {


### PR DESCRIPTION
# What does this PR introduce?

- [x] **bump version in `package.json`** from `3.1.0` > `3.1.1`
- [x] add missing content of release 3.1.0 in `CHANGELOG.md`
- [x] add content of release 3.1.1 in `CHANGELOG.md`

## Build

- edit the npm script `release` to run `standard-version` instead of `npm publish`
