### PR TITLE
fix: remove return definition in ErrorHandlerLib.revertWithParsedError(…)

### DIFF
--- a/implementations/contracts/utils/ErrorHandlerLib.sol
+++ b/implementations/contracts/utils/ErrorHandlerLib.sol
@@ -14,7 +14,6 @@ library ErrorHandlerLib {
     function revertWithParsedError(bytes memory error)
         internal
         pure
-        returns (string memory)
     {
         if (error.length > 0) {
             // the call reverted with a error string or a custom error


### PR DESCRIPTION
# What does this PR introduce?

When running Slither, the static analysis reports that the value by `ErrorHandlerLib.revertWithParsedError(...)` is ignored and not used.

## What is the current behaviour?

```
ERC725XCore.executeCall(address,uint256,bytes,uint256) (node_modules/@erc725/smart-contracts/contracts/ERC725XCore.sol#131-145) ignores return value by ErrorHandlerLib.revertWithParsedError(result) (node_modules/@erc725/smart-contracts/contracts/ERC725XCore.sol#141)

ERC725XCore.executeStaticCall(address,bytes,uint256) (node_modules/@erc725/smart-contracts/contracts/ERC725XCore.sol#154-166) ignores return value by ErrorHandlerLib.revertWithParsedError(result) (node_modules/@erc725/smart-contracts/contracts/ERC725XCore.sol#162)

ERC725XCore.executeDelegateCall(address,bytes,uint256) (node_modules/@erc725/smart-contracts/contracts/ERC725XCore.sol#177-190) ignores return value by ErrorHandlerLib.revertWithParsedError(result) (node_modules/@erc725/smart-contracts/contracts/ERC725XCore.sol#186)

Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unused-return
```

In fact, the `bytes memory result` value is actually never returned from the memory, but rather used to simply revert.

## What is the new behaviour?

remove the return parameter from the `ErrorHandlerLib.revertWithParsedError(...)` function.