### PR TITLE
refactor: optimize `onlyOwner` modifier in OwnableUnset contract

### DIFF
--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -24,7 +24,7 @@ abstract contract OwnableUnset {
      * @dev Throws if called by any account other than the owner.
      */
     modifier onlyOwner() {
-        require(owner() == msg.sender, "Ownable: caller is not the owner");
+        _checkOwner();
         _;
     }
 
@@ -46,6 +46,13 @@ abstract contract OwnableUnset {
     function transferOwnership(address newOwner) public virtual onlyOwner {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         _setOwner(newOwner);
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        require(owner() == msg.sender, "Ownable: caller is not the owner");
     }
 
     /**


### PR DESCRIPTION
## What does this PR introduce?
- optimize `onlyOwner` modifier in OwnableUnset contract.
This reduces the contract size as the require check will be called not implemented as code in each function.