### PR TITLE
fix!: lock base `ERC725XInit` and `ERC725YInit` contracts on deployment

### DIFF
--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -10,6 +10,14 @@ import {ERC725InitAbstract} from "./ERC725InitAbstract.sol";
  * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract
  */
 contract ERC725Init is ERC725InitAbstract {
+
+    /**
+     * @dev Deploy + lock base contract deployment on deployment
+     */
+    constructor() {
+        _disableInitializers();
+    }
+    
     /**
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -12,6 +12,14 @@ import {ERC725XInitAbstract} from "./ERC725XInitAbstract.sol";
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
 contract ERC725XInit is ERC725XInitAbstract {
+
+    /**
+     * @dev Deploy + lock base contract deployment on deployment
+     */
+    constructor() {
+        _disableInitializers();
+    }
+    
     /**
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -12,6 +12,14 @@ import {ERC725YInitAbstract} from "./ERC725YInitAbstract.sol";
  * from/to the contract storage
  */
 contract ERC725YInit is ERC725YInitAbstract {
+
+    /**
+     * @dev Deploy + lock base contract deployment on deployment
+     */
+    constructor() {
+        _disableInitializers();
+    }
+    
     /**
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract

--- a/implementations/test/ERC725Y.test.js
+++ b/implementations/test/ERC725Y.test.js
@@ -3,6 +3,7 @@ const { expectRevert } = require("openzeppelin-test-helpers");
 const { web3 } = require("openzeppelin-test-helpers/src/setup");
 
 const ERC725Y = artifacts.require("ERC725Y");
+const ERC725YInit = artifacts.require("ERC725YInit");
 const ReaderContract = artifacts.require("Reader");
 
 const ERC725YWriter = artifacts.require("ERC725YWriter");
@@ -1606,6 +1607,30 @@ contract("ERC725Y (from Smart Contract)", (accounts) => {
       await erc725YWriter.setDataComputed(account.address);
       let result = await erc725YReader.callGetData(account.address, key);
       assert.deepEqual(result, value);
+    });
+  });
+});
+
+contract("ERC72YXInit", (accounts) => {
+  context("after deploying the base contract", async () => {
+    before(async () => {
+      erc725YInit = await ERC725YInit.new();
+    });
+    it("should have initialized (= locked) the base contract", async () => {
+      const isInitialized = await erc725YInit.initialized.call();
+      assert.equal(isInitialized.toNumber(), 255);
+    });
+
+    it("should have set the owner of the base contract as the zero-address", async () => {
+      const owner = await erc725YInit.owner.call();
+      assert.equal(owner, "0x0000000000000000000000000000000000000000");
+    });
+
+    it("should not be possible to call `initialize(...)` on the base contract", async () => {
+      await expectRevert(
+        erc725YInit.initialize(accounts[0], { from: accounts[0] }),
+        "Initializable: contract is already initialized"
+      );
     });
   });
 });


### PR DESCRIPTION
# What does this PR introduce?

Currently, the base contract version (implementation to be used behind proxy) needs to be initialized after deployment. This create a race condition via 2 transactions.

- [x] ⛔ add a `constructor` that lock the base contract for deployment on `ERC725XInit` and `ERC725YInit`.