### PR TITLE
fix: [QSP-4] prevent `address(0)` to be set as contract owner on deployment

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -20,7 +20,7 @@ contract ERC725 is ERC725XCore, ERC725YCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) {
+    constructor(address newOwner) notZeroAddressAsOwner(newOwner) {
         OwnableUnset._setOwner(newOwner);
     }
 

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -17,7 +17,7 @@ import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
  * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract
  */
 abstract contract ERC725InitAbstract is Initializable, ERC725XCore, ERC725YCore {
-    function _initialize(address newOwner) internal virtual onlyInitializing {
+    function _initialize(address newOwner) internal virtual onlyInitializing notZeroAddressAsOwner(newOwner) {
         OwnableUnset._setOwner(newOwner);
     }
 

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -17,8 +17,7 @@ contract ERC725X is ERC725XCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) {
-        require(newOwner != address(0), "ERC725X: contract owner cannot be the zero address");
+    constructor(address newOwner) notZeroAddressAsOwner(newOwner) {
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -18,6 +18,7 @@ contract ERC725X is ERC725XCore {
      * @param newOwner the owner of the contract
      */
     constructor(address newOwner) {
+        require(newOwner != address(0), "ERC725X: contract owner cannot be the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -15,6 +15,7 @@ import {ERC725XCore} from "./ERC725XCore.sol";
  */
 abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
     function _initialize(address newOwner) internal virtual onlyInitializing {
+        require(newOwner != address(0), "ERC725X: contract owner cannot be the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -14,8 +14,7 @@ import {ERC725XCore} from "./ERC725XCore.sol";
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
 abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
-    function _initialize(address newOwner) internal virtual onlyInitializing {
-        require(newOwner != address(0), "ERC725X: contract owner cannot be the zero address");
+    function _initialize(address newOwner) internal virtual onlyInitializing notZeroAddressAsOwner(newOwner) {
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -18,8 +18,7 @@ contract ERC725Y is ERC725YCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) {
-        require(newOwner != address(0), "ERC725Y: contract owner cannot be the zero address");
+    constructor(address newOwner) notZeroAddressAsOwner(newOwner) {
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -19,6 +19,7 @@ contract ERC725Y is ERC725YCore {
      * @param newOwner the owner of the contract
      */
     constructor(address newOwner) {
+        require(newOwner != address(0), "ERC725Y: contract owner cannot be the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -14,8 +14,7 @@ import {ERC725YCore} from "./ERC725YCore.sol";
  * from/to the contract storage
  */
 abstract contract ERC725YInitAbstract is Initializable, ERC725YCore {
-    function _initialize(address newOwner) internal virtual onlyInitializing {
-        require(newOwner != address(0), "ERC725Y: contract owner cannot be the zero address");
+    function _initialize(address newOwner) internal virtual onlyInitializing notZeroAddressAsOwner(newOwner) {
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -15,6 +15,7 @@ import {ERC725YCore} from "./ERC725YCore.sol";
  */
 abstract contract ERC725YInitAbstract is Initializable, ERC725YCore {
     function _initialize(address newOwner) internal virtual onlyInitializing {
+        require(newOwner != address(0), "ERC725Y: contract owner cannot be the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -29,6 +29,17 @@ abstract contract OwnableUnset {
     }
 
     /**
+     * @dev disallow passing address(0) as parameter 
+     *      intended to be use when setting initial contract owner on deployment
+     *
+     * @param newOwner the address of the contract owner
+     */
+    modifier notZeroAddressAsOwner(address newOwner) {
+        require(newOwner != address(0), "Ownable: contract owner cannot be the zero address");
+        _;
+    }
+
+    /**
      * @dev Leaves the contract without owner. It will not be possible to call
      * `onlyOwner` functions anymore. Can only be called by the current owner.
      *

--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -30,7 +30,7 @@ abstract contract OwnableUnset {
 
     /**
      * @dev disallow passing address(0) as parameter 
-     *      intended to be use when setting initial contract owner on deployment
+     *      intended to be used when setting initial contract owner on deployment
      *
      * @param newOwner the address of the contract owner
      */

--- a/implementations/test/ERC165InterfaceId.test.ts
+++ b/implementations/test/ERC165InterfaceId.test.ts
@@ -1,6 +1,6 @@
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
-import { artifacts, ethers } from "hardhat";
+import { ethers } from "hardhat";
 
 import { ERC165InterfaceIDs, ERC165InterfaceIDs__factory } from "../types";
 

--- a/implementations/test/ERC725.test.ts
+++ b/implementations/test/ERC725.test.ts
@@ -1,0 +1,86 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+// types
+import { ERC725, ERC725__factory, ERC725Init__factory } from "../types";
+
+import { deployProxy } from "./fixtures";
+
+type ERC725DeployParams = {
+  newOwner: string;
+};
+
+type ERC725TestContext = {
+  accounts: SignerWithAddress[];
+  erc725: ERC725;
+  deployParams: ERC725DeployParams;
+};
+
+describe("ERC725", () => {
+  describe("when using ERC725 with constructor", () => {
+    describe("when deploying the contract", () => {
+      it("should revert when giving address(0) as owner", async () => {
+        const accounts = await ethers.getSigners();
+
+        const deployParams = {
+          newOwner: ethers.constants.AddressZero,
+        };
+
+        await expect(
+          new ERC725__factory(accounts[0]).deploy(deployParams.newOwner)
+        ).to.be.revertedWith(
+          "Ownable: contract owner cannot be the zero address"
+        );
+      });
+    });
+  });
+
+  describe("when using ERC725 with proxy", () => {
+    const buildTestContext = async (): Promise<ERC725TestContext> => {
+      const accounts = await ethers.getSigners();
+
+      const deployParams = {
+        newOwner: accounts[0].address,
+      };
+
+      const erc725Base = await new ERC725Init__factory(accounts[0]).deploy();
+
+      const erc725Proxy = await deployProxy(erc725Base.address, accounts[0]);
+      const erc725 = erc725Base.attach(erc725Proxy);
+
+      return { accounts, erc725, deployParams };
+    };
+
+    describe("when deploying the base implementation contract", () => {
+      it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+        const accounts = await ethers.getSigners();
+
+        const erc725Base = await new ERC725Init__factory(accounts[0]).deploy();
+
+        const randomCaller = accounts[1];
+
+        await expect(
+          erc725Base["initialize(address)"](randomCaller.address)
+        ).to.be.revertedWith("Initializable: contract is already initialized");
+      });
+    });
+
+    describe("when deploying the contract as proxy", () => {
+      let context: ERC725TestContext;
+
+      beforeEach(async () => {
+        context = await buildTestContext();
+      });
+
+      it("should revert when initializing with address(0) as owner", async () => {
+        await expect(
+          context.erc725["initialize(address)"](ethers.constants.AddressZero)
+        ).to.be.revertedWith(
+          "Ownable: contract owner cannot be the zero address"
+        );
+      });
+    });
+  });
+});

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -1,17 +1,14 @@
 import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
+
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { AddressZero } from "@ethersproject/constants";
 import type { TransactionResponse } from "@ethersproject/abstract-provider";
 
 // types
 import {
   ERC725X,
-  ERC725X__factory,
-  ERC725XInit,
-  ERC725XInit__factory,
   ReceiveTester__factory,
-  ReceiveTester,
   RevertTester__factory,
   NoReceive__factory,
   NonPayableFallbackContract__factory,

--- a/implementations/test/ERC725X.test.ts
+++ b/implementations/test/ERC725X.test.ts
@@ -33,13 +33,27 @@ describe("ERC725X", () => {
     };
 
     describe("when deploying the contract", () => {
-      let context: ERC725XTestContext;
+      it("should revert when giving address(0) as owner", async () => {
+        const accounts = await getNamedAccounts();
 
-      beforeEach(async () => {
-        context = await buildTestContext();
+        const deployParams = {
+          newOwner: ethers.constants.AddressZero,
+        };
+
+        await expect(
+          new ERC725X__factory(accounts.owner).deploy(deployParams.newOwner)
+        ).to.be.revertedWith(
+          "ERC725X: contract owner cannot be the zero address"
+        );
       });
 
-      describe("when initializing the contract", () => {
+      describe("once the contract was deployed", () => {
+        let context: ERC725XTestContext;
+
+        beforeEach(async () => {
+          context = await buildTestContext();
+        });
+
         shouldInitializeLikeERC725X(async () => {
           const { erc725X, deployParams } = context;
           return {
@@ -104,6 +118,14 @@ describe("ERC725X", () => {
 
       beforeEach(async () => {
         context = await buildTestContext();
+      });
+
+      it("should revert when initializing with address(0) as owner", async () => {
+        await expect(
+          context.erc725X["initialize(address)"](ethers.constants.AddressZero)
+        ).to.be.revertedWith(
+          "ERC725X: contract owner cannot be the zero address"
+        );
       });
 
       describe("when initializing the contract", () => {

--- a/implementations/test/ERC725X.test.ts
+++ b/implementations/test/ERC725X.test.ts
@@ -38,7 +38,7 @@ describe("ERC725X", () => {
         await expect(
           new ERC725X__factory(accounts.owner).deploy(deployParams.newOwner)
         ).to.be.revertedWith(
-          "ERC725X: contract owner cannot be the zero address"
+          "Ownable: contract owner cannot be the zero address"
         );
       });
 
@@ -119,7 +119,7 @@ describe("ERC725X", () => {
         await expect(
           context.erc725X["initialize(address)"](ethers.constants.AddressZero)
         ).to.be.revertedWith(
-          "ERC725X: contract owner cannot be the zero address"
+          "Ownable: contract owner cannot be the zero address"
         );
       });
 

--- a/implementations/test/ERC725X.test.ts
+++ b/implementations/test/ERC725X.test.ts
@@ -1,11 +1,6 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
-import {
-  ERC725X,
-  ERC725X__factory,
-  ERC725XInit,
-  ERC725XInit__factory,
-} from "../types";
+import { ERC725X__factory, ERC725XInit__factory } from "../types";
 
 import {
   getNamedAccounts,

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -1,15 +1,13 @@
 import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
+
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { AddressZero } from "@ethersproject/constants";
 import type { TransactionResponse } from "@ethersproject/abstract-provider";
 
 // types
 import {
   ERC725Y,
-  ERC725Y__factory,
-  ERC725YInit,
-  ERC725YInit__factory,
   ERC725YWriter__factory,
   ERC725YReader__factory,
 } from "../types";

--- a/implementations/test/ERC725Y.test.ts
+++ b/implementations/test/ERC725Y.test.ts
@@ -1,11 +1,6 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
-import {
-  ERC725Y,
-  ERC725Y__factory,
-  ERC725YInit,
-  ERC725YInit__factory,
-} from "../types";
+import { ERC725Y__factory, ERC725YInit__factory } from "../types";
 
 import {
   getNamedAccounts,

--- a/implementations/test/ERC725Y.test.ts
+++ b/implementations/test/ERC725Y.test.ts
@@ -39,7 +39,21 @@ describe("ERC725Y", () => {
         context = await buildTestContext();
       });
 
-      describe("when initializing the contract", () => {
+      it("should revert when giving address(0) as owner", async () => {
+        const accounts = await getNamedAccounts();
+
+        const deployParams = {
+          newOwner: ethers.constants.AddressZero,
+        };
+
+        await expect(
+          new ERC725Y__factory(accounts.owner).deploy(deployParams.newOwner)
+        ).to.be.revertedWith(
+          "ERC725Y: contract owner cannot be the zero address"
+        );
+      });
+
+      describe("once the contract was deployed", () => {
         shouldInitializeLikeERC725Y(async () => {
           const { erc725Y, deployParams } = context;
           return {
@@ -104,6 +118,14 @@ describe("ERC725Y", () => {
 
       beforeEach(async () => {
         context = await buildTestContext();
+      });
+
+      it("should revert when initializing with address(0) as owner", async () => {
+        await expect(
+          context.erc725Y["initialize(address)"](ethers.constants.AddressZero)
+        ).to.be.revertedWith(
+          "ERC725Y: contract owner cannot be the zero address"
+        );
       });
 
       describe("when initializing the contract", () => {

--- a/implementations/test/ERC725Y.test.ts
+++ b/implementations/test/ERC725Y.test.ts
@@ -44,7 +44,7 @@ describe("ERC725Y", () => {
         await expect(
           new ERC725Y__factory(accounts.owner).deploy(deployParams.newOwner)
         ).to.be.revertedWith(
-          "ERC725Y: contract owner cannot be the zero address"
+          "Ownable: contract owner cannot be the zero address"
         );
       });
 
@@ -119,7 +119,7 @@ describe("ERC725Y", () => {
         await expect(
           context.erc725Y["initialize(address)"](ethers.constants.AddressZero)
         ).to.be.revertedWith(
-          "ERC725Y: contract owner cannot be the zero address"
+          "Ownable: contract owner cannot be the zero address"
         );
       });
 


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Fix

- add additional checks to prevent contract owner to be set as `address(0)` when deploying/initializing the contract.

## 🧪 Tests

- start simple test suite for testing `ERC725.sol` and `ERC725Init.sol` contract.