### PR TITLE
refactor: improve internal functions of `ERC725XCore`

### DIFF
--- a/implementations/.prettierrc
+++ b/implementations/.prettierrc
@@ -9,6 +9,14 @@
         "trailingComma": "all",
         "singleQuote": true
       }
+    },
+    {
+      "files": "*.sol",
+      "options": {
+        "tabWidth": 4,
+        "printWidth": 100,
+        "compiler": "0.8.10"
+      }
     }
   ]
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -55,19 +55,17 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         if (operation == OPERATION_STATICCALL) return _executeStaticCall(to, value, data);
 
         // DELEGATECALL
-        // WARNING!
-        // delegatecall is a dangerous operation type!
+        //
+        // WARNING! delegatecall is a dangerous operation type! use with EXTRA CAUTION
         //
         // delegate allows to call another deployed contract and use its functions
-        // to update the state of the current calling contract
+        // to update the state of the current calling contract.
         //
         // this can lead to unexpected behaviour on the contract storage, such as:
-        //
         // - updating any state variables (even if these are protected)
         // - update the contract owner
         // - run selfdestruct in the context of this contract
         //
-        // use with EXTRA CAUTION
         if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
 
         revert("ERC725X: Unknown operation type");

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -42,6 +42,9 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         uint256 value,
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
+
+        require(address(this).balance >= value, "ERC725X: insufficient balance");
+
         // CALL
         if (operation == OPERATION_CALL) return _executeCall(to, value, data);
 
@@ -100,7 +103,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         uint256 value,
         bytes memory data
     ) internal virtual returns (bytes memory result) {
-        require(address(this).balance >= value, "ERC725X: insufficient balance for CALL");
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.call{value: value}(data);
@@ -167,7 +169,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
             to == address(0),
             "ERC725X: CREATE operations require the receiver address to be empty"
         );
-        require(address(this).balance >= value, "ERC725X: insufficient balance for CREATE");
         require(data.length != 0, "ERC725X: No contract bytecode provided");
 
         address contractAddress;
@@ -186,7 +187,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
      * @dev perform contract creation using operation 2
      * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE2)
      * @param value The value to be sent to the contract created
-     * @param data The contract bytecode to deploy combined with the salt
+     * @param data The contract bytecode to deploy appended with a bytes32 salt
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate2(
@@ -198,7 +199,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
             to == address(0),
             "ERC725X: CREATE operations require the receiver address to be empty"
         );
-        require(address(this).balance >= value, "ERC725X: insufficient balance for CREATE2");
         require(data.length != 0, "ERC725X: No contract bytecode provided");
 
         bytes32 salt = BytesLib.toBytes32(data, data.length - 32);

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -33,7 +33,6 @@ import {
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system
  */
 abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
-
     /**
      * @inheritdoc IERC725X
      */
@@ -51,10 +50,10 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
         // Deploy with CREATE2
         if (operation == OPERATION_CREATE2) return _deployCreate2(to, value, data);
-        
+
         // STATICCALL
         if (operation == OPERATION_STATICCALL) return _executeStaticCall(to, value, data);
-        
+
         // DELEGATECALL
         // WARNING!
         // delegatecall is a dangerous operation type!
@@ -71,7 +70,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         // use with EXTRA CAUTION
         if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
 
-        revert("ERC725X: Unknown operation type");    
+        revert("ERC725X: Unknown operation type");
     }
 
     /* Overrides functions */
@@ -89,7 +88,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 
-
     /* Internal functions */
 
     /**
@@ -106,11 +104,11 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes memory data
     ) internal virtual returns (bytes memory result) {
         require(address(this).balance >= value, "ERC725X: insufficient balance for CALL");
-        
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.call{value: value}(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
-        
+
         emit Executed(OPERATION_CALL, to, value, bytes4(data));
     }
 
@@ -127,11 +125,11 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes memory data
     ) internal virtual returns (bytes memory result) {
         require(value == 0, "ERC725X: cannot transfer value with operation STATICCALL");
-        
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.staticcall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
-        
+
         emit Executed(OPERATION_STATICCALL, to, value, bytes4(data));
     }
 
@@ -146,13 +144,13 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         address to,
         uint256 value,
         bytes memory data
-    ) internal virtual returns(bytes memory result) {
+    ) internal virtual returns (bytes memory result) {
         require(value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
-        
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.delegatecall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
-        
+
         emit Executed(OPERATION_DELEGATECALL, to, value, bytes4(data));
     }
 
@@ -163,8 +161,15 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
      * @param data The contract bytecode to deploy
      * @return newContract The address of the contract created
      */
-    function _deployCreate(address to, uint256 value, bytes memory data) internal virtual returns (bytes memory newContract) {
-        require(to == address(0),"ERC725X: CREATE operations require the receiver address to be empty");
+    function _deployCreate(
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal virtual returns (bytes memory newContract) {
+        require(
+            to == address(0),
+            "ERC725X: CREATE operations require the receiver address to be empty"
+        );
         require(address(this).balance >= value, "ERC725X: insufficient balance for CREATE");
         require(data.length != 0, "ERC725X: No contract bytecode provided");
 
@@ -175,7 +180,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         }
 
         require(contractAddress != address(0), "ERC725X: Could not deploy contract");
-        
+
         newContract = abi.encodePacked(contractAddress);
         emit ContractCreated(OPERATION_CREATE, contractAddress, value);
     }
@@ -187,18 +192,23 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
      * @param data The contract bytecode to deploy
      * @return newContract The address of the contract created
      */
-    function _deployCreate2(address to, uint256 value, bytes memory data) internal virtual returns (bytes memory newContract) {
-        require(to == address(0),"ERC725X: CREATE operations require the receiver address to be empty");
+    function _deployCreate2(
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal virtual returns (bytes memory newContract) {
+        require(
+            to == address(0),
+            "ERC725X: CREATE operations require the receiver address to be empty"
+        );
         require(address(this).balance >= value, "ERC725X: insufficient balance for CREATE2");
         require(data.length != 0, "ERC725X: No contract bytecode provided");
 
         bytes32 salt = BytesLib.toBytes32(data, data.length - 32);
         bytes memory bytecode = BytesLib.slice(data, 0, data.length - 32);
         address contractAddress = Create2.deploy(value, salt, bytecode);
-        
+
         newContract = abi.encodePacked(contractAddress);
         emit ContractCreated(OPERATION_CREATE2, contractAddress, value);
     }
-
-
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -90,7 +90,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
     /**
      * @dev perform call using operation 0
-     *
      * @param to The address on which call is executed
      * @param value The value to be sent with the call
      * @param data The data to be sent with the call
@@ -154,10 +153,10 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
     /**
      * @dev perform contract creation using operation 1
-     * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE2)
+     * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE)
      * @param value The value to be sent to the contract created
      * @param data The contract bytecode to deploy
-     * @return newContract The address of the contract created
+     * @return newContract The address of the contract created as bytes
      */
     function _deployCreate(
         address to,
@@ -187,8 +186,8 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
      * @dev perform contract creation using operation 2
      * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE2)
      * @param value The value to be sent to the contract created
-     * @param data The contract bytecode to deploy
-     * @return newContract The address of the contract created
+     * @param data The contract bytecode to deploy combined with the salt
+     * @return newContract The address of the contract created as bytes
      */
     function _deployCreate2(
         address to,

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -71,8 +71,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         // use with EXTRA CAUTION
         if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
 
-        revert("ERC725X: Unknown operation type");
-    
+        revert("ERC725X: Unknown operation type");    
     }
 
     /* Overrides functions */
@@ -109,7 +108,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         require(address(this).balance >= value, "ERC725X: insufficient balance for CALL");
         
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory returnData) = to.call{gas: gasleft(), value: value}(data);
+        (bool success, bytes memory returnData) = to.call{value: value}(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
         
         emit Executed(OPERATION_CALL, to, value, bytes4(data));
@@ -130,7 +129,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         require(value == 0, "ERC725X: cannot transfer value with operation STATICCALL");
         
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory returnData) = to.staticcall{gas: gasleft()}(data);
+        (bool success, bytes memory returnData) = to.staticcall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
         
         emit Executed(OPERATION_STATICCALL, to, value, bytes4(data));
@@ -151,7 +150,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         require(value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
         
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory returnData) = to.delegatecall{gas: gasleft()}(data);
+        (bool success, bytes memory returnData) = to.delegatecall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
         
         emit Executed(OPERATION_DELEGATECALL, to, value, bytes4(data));
@@ -159,7 +158,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
     /**
      * @dev perform contract creation using operation 1
-     *
+     * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE2)
      * @param value The value to be sent to the contract created
      * @param data The contract bytecode to deploy
      * @return newContract The address of the contract created
@@ -183,7 +182,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
     /**
      * @dev perform contract creation using operation 2
-     *
+     * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE2)
      * @param value The value to be sent to the contract created
      * @param data The contract bytecode to deploy
      * @return newContract The address of the contract created

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -90,6 +90,7 @@ export const shouldBehaveLikeERC725X = (
     context = await buildContext();
     provider = ethers.provider;
     abiCoder = new ethers.utils.AbiCoder();
+
     // fund erc725X contract
     valueToSend = ethers.utils.parseEther("50");
     await context.erc725X
@@ -509,7 +510,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance for call");
+            ).to.be.revertedWith("ERC725X: insufficient balance for CALL");
           });
         });
       });
@@ -952,7 +953,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("Could not deploy contract");
+            ).to.be.revertedWith("ERC725X: Could not deploy contract");
           });
         });
 
@@ -1051,7 +1052,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance for call");
+            ).to.be.revertedWith("ERC725X: insufficient balance for CREATE");
           });
         });
 
@@ -1073,7 +1074,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("Could not deploy contract");
+            ).to.be.revertedWith("ERC725X: Could not deploy contract");
           });
         });
       });
@@ -1405,7 +1406,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance for call");
+            ).to.be.revertedWith("ERC725X: insufficient balance for CREATE2");
           });
         });
 
@@ -1917,7 +1918,7 @@ export const shouldBehaveLikeERC725X = (
               txParams.value,
               txParams.data
             )
-        ).to.be.revertedWith("Wrong operation type");
+        ).to.be.revertedWith("ERC725X: Unknown operation type");
       });
     });
   });

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -510,7 +510,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance for CALL");
+            ).to.be.revertedWith("ERC725X: insufficient balance");
           });
         });
       });
@@ -1052,7 +1052,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance for CREATE");
+            ).to.be.revertedWith("ERC725X: insufficient balance");
           });
         });
 
@@ -1406,7 +1406,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance for CREATE2");
+            ).to.be.revertedWith("ERC725X: insufficient balance");
           });
         });
 


### PR DESCRIPTION
# What does this PR introduce?

- Improve the internal functions of `ERC725XCore.sol`, so to allow better and easier overriding of the `execute(...)` function.
- mark the `internal` functions as `virtual`, so they can be overridden individually.

> made in peer programming with @YamenMerhi 🤝 using [VS Code Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare-pack) extension.