### PR TITLE
feat!: add `bytes dataValue` parameter to `DataChanged` event in ERC725Y

### DIFF
--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -88,7 +88,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
 
     function _setData(bytes32 dataKey, bytes memory dataValue) internal virtual {
         store[dataKey] = dataValue;
-        emit DataChanged(dataKey);
+        emit DataChanged(dataKey, dataValue);
     }
 
     /**

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -14,8 +14,9 @@ interface IERC725Y is IERC165 {
     /**
      * @notice Emitted when data at a key is changed
      * @param dataKey The data key which value is set
+     * @param dataValue The data value which is set to the key
      */
-    event DataChanged(bytes32 indexed dataKey);
+    event DataChanged(bytes32 indexed dataKey, bytes indexed dataValue);
 
     /**
      * @notice Gets singular data at a given `dataKey`

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -13,10 +13,10 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 interface IERC725Y is IERC165 {
     /**
      * @notice Emitted when data at a key is changed
-     * @param dataKey The data key which value is set
-     * @param dataValue The data value which is set to the key
+     * @param dataKey The data key which data value is set
+     * @param dataValue The data value to set
      */
-    event DataChanged(bytes32 indexed dataKey, bytes indexed dataValue);
+    event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
     /**
      * @notice Gets singular data at a given `dataKey`

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -124,7 +124,7 @@ export const shouldBehaveLikeERC725Y = (
               ["setData(bytes32,bytes)"](txParams.dataKey, txParams.dataValue)
           )
             .to.emit(context.erc725Y, "DataChanged")
-            .withArgs(txParams.dataKey);
+            .withArgs(txParams.dataKey, txParams.dataValue);
 
           const fetchedData = await context.erc725Y.callStatic[
             "getData(bytes32)"
@@ -189,7 +189,7 @@ export const shouldBehaveLikeERC725Y = (
               )
           )
             .to.emit(context.erc725Y, "DataChanged")
-            .withArgs(txParams.dataKey);
+            .withArgs(txParams.dataKey, txParams.dataValue);
 
           const fetchedData = await context.erc725Y.callStatic[
             "getData(bytes32)"
@@ -216,7 +216,7 @@ export const shouldBehaveLikeERC725Y = (
                 ["setData(bytes32,bytes)"](txParams.dataKey, txParams.dataValue)
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(txParams.dataKey);
+              .withArgs(txParams.dataKey, txParams.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -266,7 +266,7 @@ export const shouldBehaveLikeERC725Y = (
                 )
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(tx2Params.dataKey);
+              .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -317,7 +317,7 @@ export const shouldBehaveLikeERC725Y = (
                 )
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(tx2Params.dataKey);
+              .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -343,7 +343,7 @@ export const shouldBehaveLikeERC725Y = (
                 ["setData(bytes32,bytes)"](txParams.dataKey, txParams.dataValue)
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(txParams.dataKey);
+              .withArgs(txParams.dataKey, txParams.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -374,7 +374,7 @@ export const shouldBehaveLikeERC725Y = (
               )
           )
             .to.emit(context.erc725Y, "DataChanged")
-            .withArgs(txParams.dataKey);
+            .withArgs(txParams.dataKey, txParams.dataValue);
 
           const fetchedData = await context.erc725Y.callStatic[
             "getData(bytes32)"
@@ -442,7 +442,7 @@ export const shouldBehaveLikeERC725Y = (
               )
           )
             .to.emit(context.erc725Y, "DataChanged")
-            .withArgs(txParams.dataKey);
+            .withArgs(txParams.dataKey, txParams.dataValue);
 
           const fetchedData = await context.erc725Y.callStatic[
             "getData(bytes32)"
@@ -472,7 +472,7 @@ export const shouldBehaveLikeERC725Y = (
                 )
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(txParams.dataKey);
+              .withArgs(txParams.dataKey, txParams.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -521,7 +521,7 @@ export const shouldBehaveLikeERC725Y = (
                 )
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(tx2Params.dataKey);
+              .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -571,7 +571,7 @@ export const shouldBehaveLikeERC725Y = (
                 )
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(tx2Params.dataKey);
+              .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"
@@ -600,7 +600,7 @@ export const shouldBehaveLikeERC725Y = (
                 )
             )
               .to.emit(context.erc725Y, "DataChanged")
-              .withArgs(txParams.dataKey);
+              .withArgs(txParams.dataKey, txParams.dataValue);
 
             const fetchedData = await context.erc725Y.callStatic[
               "getData(bytes32)"


### PR DESCRIPTION
## What does this PR introduce?

## ⚠️ Breaking Change

In this PR a new parameter is added to the `DataChanged` event, `dataValue`.
Also the tests are fixed in order to take into account `dataValue` whenever it is checked if the event `DataChanged` was emitted.