### PR TITLE
docs: remove space between "ERC" and "725" in main README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ERC 725 &middot; [![npm version](https://img.shields.io/npm/v/@erc725/smart-contracts.svg?style=flat)](https://www.npmjs.com/package/@erc725/smart-contracts) [![Coverage Status](https://coveralls.io/repos/github/ERC725Alliance/ERC725/badge.svg?branch=develop)](https://coveralls.io/github/ERC725Alliance/ERC725?branch=develop)
+# ERC725 &middot; [![npm version](https://img.shields.io/npm/v/@erc725/smart-contracts.svg?style=flat)](https://www.npmjs.com/package/@erc725/smart-contracts) [![Coverage Status](https://coveralls.io/repos/github/ERC725Alliance/ERC725/badge.svg?branch=develop)](https://coveralls.io/github/ERC725Alliance/ERC725?branch=develop)
 
 Repository for the code and standard documents around ERC725 and related standards
 
-## ERC 725 Use Cases
+## ERC725 Use Cases
 
 Projects building on ERC725 are invited to add themselves to the table [here](https://github.com/ERC725Alliance/ERC725/blob/master/docs/use-cases.md).
 

--- a/docs/ERC-734.md
+++ b/docs/ERC-734.md
@@ -16,7 +16,7 @@ A contract for key management of a blockchain proxy account.
 
 ## Abstract
 The following describes standard functions for a key manager to be used in conjunction with [ERC725](https://github.com/ethereum/EIPs/issues/725).
-This contract can hold keys to sign actions (transactions, documents, logins, access, etc), as well as execute instructions through an ERC 725 proxy account.
+This contract can hold keys to sign actions (transactions, documents, logins, access, etc), as well as execute instructions through an ERC725 proxy account.
 
 ## Motivation
 This key manager standard allows for more complex management of an [ERC725](https://github.com/ethereum/EIPs/issues/725) proxy account.


### PR DESCRIPTION
change from this:

<img width="934" alt="image" src="https://user-images.githubusercontent.com/31145285/188201866-90d79cd7-7f3c-41df-a4ea-7a08b39a1991.png">

to this:

<img width="937" alt="image" src="https://user-images.githubusercontent.com/31145285/188201909-21a35946-8237-44cc-ab39-beaf2eeca292.png">
