### PR TITLE
refactor: create internal `_execute(...)` function in ERC725X

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -41,7 +41,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         address to,
         uint256 value,
         bytes memory data
-    ) public payable virtual override onlyOwner returns (bytes memory) {
+    ) public payable virtual onlyOwner returns (bytes memory) {
         require(address(this).balance >= value, "ERC725X: insufficient balance");
         return _execute(operation, to, value, data);
     }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -96,7 +96,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
 
         revert("ERC725X: Unknown operation type");
-    } 
+    }
 
     /**
      * @dev perform call using operation 0

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -43,7 +43,32 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
         require(address(this).balance >= value, "ERC725X: insufficient balance");
+        return _execute(operation, to, value, data);
+    }
 
+    /* Overrides functions */
+
+    /**
+     * @inheritdoc ERC165
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165)
+        returns (bool)
+    {
+        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
+    }
+
+    /* Internal functions */
+
+    function _execute(
+        uint256 operation,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal virtual returns (bytes memory) {
         // CALL
         if (operation == OPERATION_CALL) return _executeCall(to, value, data);
 
@@ -71,24 +96,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
 
         revert("ERC725X: Unknown operation type");
-    }
-
-    /* Overrides functions */
-
-    /**
-     * @inheritdoc ERC165
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(IERC165, ERC165)
-        returns (bool)
-    {
-        return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
-    }
-
-    /* Internal functions */
+    } 
 
     /**
      * @dev perform call using operation 0

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -33,7 +33,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         public
         view
         virtual
-        override
         returns (bytes memory dataValue)
     {
         dataValue = _getData(dataKey);
@@ -46,7 +45,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         public
         view
         virtual
-        override
         returns (bytes[] memory dataValues)
     {
         dataValues = new bytes[](dataKeys.length);
@@ -61,7 +59,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function setData(bytes32 dataKey, bytes memory dataValue) public virtual override onlyOwner {
+    function setData(bytes32 dataKey, bytes memory dataValue) public virtual onlyOwner {
         _setData(dataKey, dataValue);
     }
 
@@ -71,7 +69,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
         public
         virtual
-        override
         onlyOwner
     {
         require(dataKeys.length == dataValues.length, "Keys length not equal to values length");

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -29,12 +29,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function getData(bytes32 dataKey)
-        public
-        view
-        virtual
-        returns (bytes memory dataValue)
-    {
+    function getData(bytes32 dataKey) public view virtual returns (bytes memory dataValue) {
         dataValue = _getData(dataKey);
     }
 


### PR DESCRIPTION
# What does this PR introduce?

In `ERC725XCore`, move all the logic of execute function inside an internal `_execute(....)` function.
This will allow easier overriding of the public function `execute(...)` for custom logic.

Aside of that, removed the unnecessary `override` keyword for functions that are directly implementation of the `IERC725X` and `IERC725Y` interfaces.