### PR TITLE
fix: emit `Executed(..)` event before the external calls

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -110,11 +110,11 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         uint256 value,
         bytes memory data
     ) internal virtual returns (bytes memory result) {
+        emit Executed(OPERATION_CALL, to, value, bytes4(data));
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.call{value: value}(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
-
-        emit Executed(OPERATION_CALL, to, value, bytes4(data));
     }
 
     /**
@@ -131,11 +131,11 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     ) internal virtual returns (bytes memory result) {
         require(value == 0, "ERC725X: cannot transfer value with operation STATICCALL");
 
+        emit Executed(OPERATION_STATICCALL, to, value, bytes4(data));
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.staticcall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
-
-        emit Executed(OPERATION_STATICCALL, to, value, bytes4(data));
     }
 
     /**
@@ -152,11 +152,11 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     ) internal virtual returns (bytes memory result) {
         require(value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
+        emit Executed(OPERATION_DELEGATECALL, to, value, bytes4(data));
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.delegatecall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
-
-        emit Executed(OPERATION_DELEGATECALL, to, value, bytes4(data));
     }
 
     /**


### PR DESCRIPTION
## What does this PR introduce?

This PR fixes some potential issues by emitting the `Executed(..)` event before the external calls inside the internal methods: `_executeCall(..)`, `_executeStaticCall(..)` and `_executeDelegateCall(..)`.

This is done in order to preserve the check-effect-interaction pattern, emitting an event being a effect and the external calls being interactions.

## [Context](https://github.com/lukso-network/lsp-smart-contracts/pull/333)