### PR TITLE
perf!: replace error strings by custom errors + use `enum` for `OPERATION_TYPE`

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -55,20 +55,20 @@ _Parameters:_
 - `operationType`: the operation type used to execute.
 - `to`: the smart contract or address to call. `to` will be unused if a contract is created (operation types 1 and 2).
 - `value`: the amount of native tokens to transfer (in Wei).
-- `data`: the call data, or the creation bytecode of the contract to deploy (runtime + constructor code).
+- `data`: the call data, or the creation bytecode of the contract to deploy (constructor + runtime code).
 
 #### data parameter
 
 - For operationType, `CALL`, `STATICCALL` and `DELEGATECALL` the data field can be random bytes or an abi-encoded function call.
 
-- For operationType, `CREATE` the data field is the runtime bytecode of the contract to deploy appended with the constructor argument abi-encoded.
+- For operationType, `CREATE` the `data` field is the constructor + runtime bytecode of the contract to deploy appended with the constructor argument(s) abi-encoded.
 
-- For operationType, `CREATE2` the data field is the runtime bytecode of the contract to deploy appended with:
-    1. the constructor argument abi-encoded
+- For operationType, `CREATE2` the `data` field is the constructor + runtime bytecode of the contract to deploy appended with:
+    1. the constructor argument(s) abi-encoded
     2. a bytes32 salt. 
 
 ```
-data = <contract-bytecode> + <abi-encoded-constructor-arguments> + <bytes32-salt>
+data = <contract-creation-code> + <abi-encoded-constructor-arguments> + <bytes32-salt>
 ```
     
 > Check [EIP-1014: Skinny CREATE2](https://eips.ethereum.org/EIPS/eip-1014) for more information.

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -55,15 +55,15 @@ _Parameters:_
 - `operationType`: the operation type used to execute.
 - `to`: the smart contract or address to call. `to` will be unused if a contract is created (operation types 1 and 2).
 - `value`: the amount of native tokens to transfer (in Wei).
-- `data`: the call data, or the creation bytecode of the contract to deploy (constructor + runtime code).
+- `data`: the call data, or the creation bytecode of the contract to deploy.
 
 #### data parameter
 
 - For operationType, `CALL`, `STATICCALL` and `DELEGATECALL` the data field can be random bytes or an abi-encoded function call.
 
-- For operationType, `CREATE` the `data` field is the constructor + runtime bytecode of the contract to deploy appended with the constructor argument(s) abi-encoded.
+- For operationType, `CREATE` the `data` field is the creation bytecode of the contract to deploy appended with the constructor argument(s) abi-encoded.
 
-- For operationType, `CREATE2` the `data` field is the constructor + runtime bytecode of the contract to deploy appended with:
+- For operationType, `CREATE2` the `data` field is the creation bytecode of the contract to deploy appended with:
     1. the constructor argument(s) abi-encoded
     2. a bytes32 salt. 
 

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -55,15 +55,15 @@ _Parameters:_
 - `operationType`: the operation type used to execute.
 - `to`: the smart contract or address to call. `to` will be unused if a contract is created (operation types 1 and 2).
 - `value`: the amount of native tokens to transfer (in Wei).
-- `data`: the call data, or the bytecode of the contract to deploy.
+- `data`: the call data, or the creation bytecode of the contract to deploy (runtime + constructor code).
 
 #### data parameter
 
 - For operationType, `CALL`, `STATICCALL` and `DELEGATECALL` the data field can be random bytes or an abi-encoded function call.
 
-- For operationType, `CREATE` the data field is the bytecode of the contract to deploy appended with the constructor argument abi-encoded.
+- For operationType, `CREATE` the data field is the runtime bytecode of the contract to deploy appended with the constructor argument abi-encoded.
 
-- For operationType, `CREATE2` the data field is the bytecode of the contract to deploy appended with:
+- For operationType, `CREATE2` the data field is the runtime bytecode of the contract to deploy appended with:
     1. the constructor argument abi-encoded
     2. a bytes32 salt. 
 

--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -52,8 +52,8 @@ MUST only be called by the current owner of the contract.
 
 _Parameters:_
 
-- `operationType`: the operation to execute.
-- `to`: the smart contract or address to interact with. `to` will be unused if a contract is created (operation 1 and 2).
+- `operationType`: the operation type used to execute.
+- `to`: the smart contract or address to call. `to` will be unused if a contract is created (operation types 1 and 2).
 - `value`: the amount of native tokens to transfer (in Wei).
 - `data`: the call data, or the bytecode of the contract to deploy.
 
@@ -63,10 +63,18 @@ _Parameters:_
 
 - For operationType, `CREATE` the data field is the bytecode of the contract to deploy appended with the constructor argument abi-encoded.
 
-- For operationType, `CREATE2` the data field is the bytecode of the contract to deploy appended with the constructor argument abi-encoded appended with a bytes32 salt. Check [EIP-1014: Skinny CREATE2](https://eips.ethereum.org/EIPS/eip-1014) for more information.
+- For operationType, `CREATE2` the data field is the bytecode of the contract to deploy appended with:
+    1. the constructor argument abi-encoded
+    2. a bytes32 salt. 
+
+```
+data = <contract-bytecode> + <abi-encoded-constructor-arguments> + <bytes32-salt>
+```
+    
+> Check [EIP-1014: Skinny CREATE2](https://eips.ethereum.org/EIPS/eip-1014) for more information.
   
 
-_Returns:_ `bytes` , the returned data of the called function, or the address of the contract created (operation 1 and 2).
+_Returns:_ `bytes` , the returned data of the called function, or the address of the contract deployed (operation types 1 and 2).
 
 The following `operationType` MUST exist:
 
@@ -74,7 +82,7 @@ The following `operationType` MUST exist:
 - `1` for `CREATE`
 - `2` for `CREATE2`
 - `3` for `STATICCALL`
-- `4` for `DELEGATECALL` - **NOTE** This is a potentially dangerous operation
+- `4` for `DELEGATECALL` - **NOTE** This is a potentially dangerous operation type
 
 Others may be added in the future.
 
@@ -87,7 +95,7 @@ Others may be added in the future.
 #### Executed
 
 ```solidity
-event Executed(uint256 indexed operation, address indexed to, uint256 indexed _value, bytes4 data);
+event Executed(uint256 indexed operationType, address indexed to, uint256 indexed _value, bytes4 data);
 ```
 
 MUST be triggered when `execute` creates a new call using the `operationType` `0`, `3`, `4`.
@@ -95,7 +103,7 @@ MUST be triggered when `execute` creates a new call using the `operationType` `0
 #### ContractCreated
 
 ```solidity
-event ContractCreated(uint256 indexed operation, address indexed contractAddress, uint256 indexed value);
+event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value);
 ```
 
 MUST be triggered when `execute` creates a new contract using the `operationType` `1`, `2`.
@@ -213,7 +221,7 @@ Reference implementations can be found [here](../assets/eip-725)
 
 This contract allows generic executions, therefore special care need to be take care to prevent re-entrancy attacks and other forms for call chain attacks.
 
-When using the operator `4` for the `delegatecall` operation, its important to consider that called contracts can alter the state of the calling contract and also change owner variables at will. Additionally calls to `selfdestruct` are possible and other harmful state changing operations.
+When using the operation type `4` for `delegatecall`, it is important to consider that called contracts can alter the state of the calling contract and also change owner variables at will. Additionally calls to `selfdestruct` are possible and other harmful state changing operations.
 
 ### Solidity Interfaces
 
@@ -223,8 +231,8 @@ pragma solidity >=0.5.0 <0.7.0;
 
 // ERC165 identifier: `0x44c028fe`
 interface IERC725X  /* is ERC165, ERC173 */ {
-    event ContractCreated(uint256 indexed operation, address indexed contractAddress, uint256 indexed value);
-    event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes4 data);
+    event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value);
+    event Executed(uint256 indexed operationType, address indexed to, uint256 indexed  value, bytes4 data);
 
     function execute(uint256 operationType, address to, uint256 value, bytes memory data) external payable returns(bytes memory);
 }

--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -26,8 +26,6 @@ contract ERC725 is ERC725XCore, ERC725YCore {
 
     // NOTE this implementation has not by default: receive() external payable {}
 
-    /* Overrides functions */
-
     /**
      * @inheritdoc ERC165
      */

--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -20,7 +20,8 @@ contract ERC725 is ERC725XCore, ERC725YCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) notZeroAddressAsOwner(newOwner) {
+    constructor(address newOwner) {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -21,8 +21,8 @@ abstract contract ERC725InitAbstract is Initializable, ERC725XCore, ERC725YCore 
         internal
         virtual
         onlyInitializing
-        notZeroAddressAsOwner(newOwner)
     {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -28,8 +28,6 @@ abstract contract ERC725InitAbstract is Initializable, ERC725XCore, ERC725YCore 
 
     // NOTE this implementation has not by default: receive() external payable {}
 
-    /* Overrides functions */
-
     /**
      * @inheritdoc ERC165
      */

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -17,7 +17,8 @@ contract ERC725X is ERC725XCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) notZeroAddressAsOwner(newOwner) {
+    constructor(address newOwner) {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -20,19 +20,7 @@ import {
     OPERATION_TYPE
 } from "./constants.sol";
 
-error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
-
-error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
-
-error ERC725X_MsgValueDisallowedInStaticCall();
-
-error ERC725X_MsgValueDisallowedInDelegateCall();
-
-error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
-
-error ERC725X_ContractDeploymentFailed();
-
-error ERC725X_NoContractBytecodeProvided();
+import "./errors.sol";
 
 /**
  * @title Core implementation of ERC725X executor
@@ -70,6 +58,10 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
 
+    /**
+     * @dev check the `operationType` provided and perform the associated low-level opcode.
+     * see `IERC725X.execute(...)`.
+     */
     function _execute(
         uint256 operationType,
         address to,

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -15,10 +15,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 
 // constants
-import {
-    _INTERFACEID_ERC725X,
-    OPERATION_TYPE
-} from "./constants.sol";
+import {_INTERFACEID_ERC725X, OPERATION_TYPE} from "./constants.sol";
 
 import "./errors.sol";
 
@@ -132,7 +129,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
             revert ERC725X_MsgValueDisallowedInStaticCall();
         }
 
-        emit Executed(3, to, value, bytes4(data));
+        emit Executed(uint256(OPERATION_TYPE.STATICCALL), to, value, bytes4(data));
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.staticcall(data);
@@ -155,14 +152,12 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
             revert ERC725X_MsgValueDisallowedInDelegateCall();
         }
 
-        emit Executed(4, to, value, bytes4(data));
+        emit Executed(uint256(OPERATION_TYPE.DELEGATECALL), to, value, bytes4(data));
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.delegatecall(data);
         result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
     }
-
-   
 
     /**
      * @dev deploy a contract using the CREATE opcode (operation type = 1)
@@ -195,7 +190,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         }
 
         newContract = abi.encodePacked(contractAddress);
-        emit ContractCreated(1, contractAddress, value);
+        emit ContractCreated(uint256(OPERATION_TYPE.CREATE), contractAddress, value);
     }
 
     /**
@@ -223,6 +218,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         address contractAddress = Create2.deploy(value, salt, bytecode);
 
         newContract = abi.encodePacked(contractAddress);
-        emit ContractCreated(2, contractAddress, value);
+        emit ContractCreated(uint256(OPERATION_TYPE.CREATE2), contractAddress, value);
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -164,7 +164,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @dev deploy a contract using the CREATE opcode (operation type = 1)
      * @param value The value to be sent to the contract created
-     * @param creationCode The contract creation bytecode to deploy (runtime + constructor code)
+     * @param creationCode The contract creation bytecode to deploy (constructor + runtime code)
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate(
@@ -192,7 +192,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @dev deploy a contract using the CREATE2 opcode (operation type = 2)
      * @param value The value to be sent to the contract created
-     * @param creationCode The contract creation bytecode to deploy (runtime + constructor code) appended with a bytes32 salt
+     * @param creationCode The contract creation bytecode to deploy (constructor + runtime code) appended with a bytes32 salt
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate2(

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -164,21 +164,21 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @dev deploy a contract using the CREATE opcode (operation type = 1)
      * @param value The value to be sent to the contract created
-     * @param data The contract bytecode to deploy
+     * @param creationCode The contract creation bytecode to deploy (runtime + constructor code)
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate(
         uint256 value,
-        bytes memory data
+        bytes memory creationCode
     ) internal virtual returns (bytes memory newContract) {
-        if (data.length == 0) {
+        if (creationCode.length == 0) {
             revert ERC725X_NoContractBytecodeProvided();
         }
 
         address contractAddress;
         // solhint-disable no-inline-assembly
         assembly {
-            contractAddress := create(value, add(data, 0x20), mload(data))
+            contractAddress := create(value, add(creationCode, 0x20), mload(creationCode))
         }
 
         if (contractAddress == address(0)) {
@@ -192,19 +192,19 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @dev deploy a contract using the CREATE2 opcode (operation type = 2)
      * @param value The value to be sent to the contract created
-     * @param data The contract bytecode to deploy appended with a bytes32 salt
+     * @param creationCode The contract creation bytecode to deploy (runtime + constructor code) appended with a bytes32 salt
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate2(
         uint256 value,
-        bytes memory data
+        bytes memory creationCode
     ) internal virtual returns (bytes memory newContract) {
-        if (data.length == 0) {
+        if (creationCode.length == 0) {
             revert ERC725X_NoContractBytecodeProvided();
         }
 
-        bytes32 salt = BytesLib.toBytes32(data, data.length - 32);
-        bytes memory bytecode = BytesLib.slice(data, 0, data.length - 32);
+        bytes32 salt = BytesLib.toBytes32(creationCode, creationCode.length - 32);
+        bytes memory bytecode = BytesLib.slice(creationCode, 0, creationCode.length - 32);
         address contractAddress = Create2.deploy(value, salt, bytecode);
 
         newContract = abi.encodePacked(contractAddress);

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -26,7 +26,7 @@ import {
 } from "./constants.sol";
 
 /**
- * @title Core implementation of ERC725 X executor
+ * @title Core implementation of ERC725X executor
  * @author Fabian Vogelsteller <fabian@lukso.network>
  * @dev Implementation of a contract module which provides the ability to call arbitrary functions at any other smart contract and itself,
  * including using `delegatecall`, `staticcall` as well creating contracts using `create` and `create2`
@@ -37,16 +37,14 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
      * @inheritdoc IERC725X
      */
     function execute(
-        uint256 operation,
+        uint256 operationType,
         address to,
         uint256 value,
         bytes memory data
     ) public payable virtual onlyOwner returns (bytes memory) {
         require(address(this).balance >= value, "ERC725X: insufficient balance");
-        return _execute(operation, to, value, data);
+        return _execute(operationType, to, value, data);
     }
-
-    /* Overrides functions */
 
     /**
      * @inheritdoc ERC165
@@ -60,8 +58,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     {
         return interfaceId == _INTERFACEID_ERC725X || super.supportsInterface(interfaceId);
     }
-
-    /* Internal functions */
 
     function _execute(
         uint256 operation,
@@ -99,7 +95,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     }
 
     /**
-     * @dev perform call using operation 0
+     * @dev perform low-level call (operation type = 0)
      * @param to The address on which call is executed
      * @param value The value to be sent with the call
      * @param data The data to be sent with the call
@@ -118,7 +114,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     }
 
     /**
-     * @dev perform staticcall using operation 3
+     * @dev perform low-level staticcall (operation type = 3)
      * @param to The address on which staticcall is executed
      * @param value The value passed to the execute(...) function (MUST be 0)
      * @param data The data to be sent with the staticcall
@@ -139,7 +135,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     }
 
     /**
-     * @dev perform delegatecall using operation 4
+     * @dev perform low-level delegatecall (operation type = 4)
      * @param to The address on which delegatecall is executed
      * @param value The value passed to the execute(...) function (MUST be 0)
      * @param data The data to be sent with the delegatecall
@@ -160,7 +156,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     }
 
     /**
-     * @dev perform contract creation using operation 1
+     * @dev deploy a contract using the CREATE opcode (operation type = 1)
      * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE)
      * @param value The value to be sent to the contract created
      * @param data The contract bytecode to deploy
@@ -190,7 +186,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     }
 
     /**
-     * @dev perform contract creation using operation 2
+     * @dev deploy a contract using the CREATE2 opcode (operation type = 2)
      * @param to The recipient address passed to execute(...) (MUST be address(0) for CREATE2)
      * @param value The value to be sent to the contract created
      * @param data The contract bytecode to deploy appended with a bytes32 salt

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -164,7 +164,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @dev deploy a contract using the CREATE opcode (operation type = 1)
      * @param value The value to be sent to the contract created
-     * @param creationCode The contract creation bytecode to deploy (constructor + runtime code)
+     * @param creationCode The contract creation bytecode to deploy appended with the constructor argument(s)
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate(
@@ -192,7 +192,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @dev deploy a contract using the CREATE2 opcode (operation type = 2)
      * @param value The value to be sent to the contract created
-     * @param creationCode The contract creation bytecode to deploy (constructor + runtime code) appended with a bytes32 salt
+     * @param creationCode The contract creation bytecode to deploy appended with the constructor argument(s) and a bytes32 salt
      * @return newContract The address of the contract created as bytes
      */
     function _deployCreate2(

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -15,14 +15,9 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 
 // constants
-// prettier-ignore
 import {
     _INTERFACEID_ERC725X,
-    OPERATION_CALL, 
-    OPERATION_DELEGATECALL, 
-    OPERATION_STATICCALL, 
-    OPERATION_CREATE, 
-    OPERATION_CREATE2
+    OPERATION_TYPE
 } from "./constants.sol";
 
 /**
@@ -66,16 +61,16 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes memory data
     ) internal virtual returns (bytes memory) {
         // CALL
-        if (operation == OPERATION_CALL) return _executeCall(to, value, data);
+        if (operation == uint256(OPERATION_TYPE.CALL)) return _executeCall(to, value, data);
 
         // Deploy with CREATE
-        if (operation == OPERATION_CREATE) return _deployCreate(to, value, data);
+        if (operation == uint256(OPERATION_TYPE.CREATE)) return _deployCreate(to, value, data);
 
         // Deploy with CREATE2
-        if (operation == OPERATION_CREATE2) return _deployCreate2(to, value, data);
+        if (operation == uint256(OPERATION_TYPE.CREATE2)) return _deployCreate2(to, value, data);
 
         // STATICCALL
-        if (operation == OPERATION_STATICCALL) return _executeStaticCall(to, value, data);
+        if (operation == uint256(OPERATION_TYPE.STATICCALL)) return _executeStaticCall(to, value, data);
 
         // DELEGATECALL
         //
@@ -89,7 +84,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         // - update the contract owner
         // - run selfdestruct in the context of this contract
         //
-        if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
+        if (operation == uint256(OPERATION_TYPE.DELEGATECALL)) return _executeDelegateCall(to, value, data);
 
         revert("ERC725X: Unknown operation type");
     }
@@ -106,7 +101,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         uint256 value,
         bytes memory data
     ) internal virtual returns (bytes memory result) {
-        emit Executed(OPERATION_CALL, to, value, bytes4(data));
+        emit Executed(uint256(OPERATION_TYPE.CALL), to, value, bytes4(data));
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.call{value: value}(data);
@@ -127,7 +122,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     ) internal virtual returns (bytes memory result) {
         require(value == 0, "ERC725X: cannot transfer value with operation STATICCALL");
 
-        emit Executed(OPERATION_STATICCALL, to, value, bytes4(data));
+        emit Executed(uint256(OPERATION_TYPE.STATICCALL), to, value, bytes4(data));
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.staticcall(data);
@@ -148,7 +143,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     ) internal virtual returns (bytes memory result) {
         require(value == 0, "ERC725X: cannot transfer value with operation DELEGATECALL");
 
-        emit Executed(OPERATION_DELEGATECALL, to, value, bytes4(data));
+        emit Executed(uint256(OPERATION_TYPE.DELEGATECALL), to, value, bytes4(data));
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = to.delegatecall(data);
@@ -182,7 +177,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         require(contractAddress != address(0), "ERC725X: Could not deploy contract");
 
         newContract = abi.encodePacked(contractAddress);
-        emit ContractCreated(OPERATION_CREATE, contractAddress, value);
+        emit ContractCreated(uint256(OPERATION_TYPE.CREATE), contractAddress, value);
     }
 
     /**
@@ -208,6 +203,6 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         address contractAddress = Create2.deploy(value, salt, bytecode);
 
         newContract = abi.encodePacked(contractAddress);
-        emit ContractCreated(OPERATION_CREATE2, contractAddress, value);
+        emit ContractCreated(uint256(OPERATION_TYPE.CREATE2), contractAddress, value);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -18,8 +18,8 @@ abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
         internal
         virtual
         onlyInitializing
-        notZeroAddressAsOwner(newOwner)
     {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -18,7 +18,8 @@ contract ERC725Y is ERC725YCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) notZeroAddressAsOwner(newOwner) {
+    constructor(address newOwner) {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -27,7 +27,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
      */
     mapping(bytes32 => bytes) internal _store;
 
-    /* Public functions */
     /**
      * @inheritdoc IERC725Y
      */
@@ -77,8 +76,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         }
     }
 
-    /* Internal functions */
-
     function _getData(bytes32 dataKey) internal view virtual returns (bytes memory dataValue) {
         return _store[dataKey];
     }
@@ -97,8 +94,6 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
             return i + 1;
         }
     }
-
-    /* Overrides functions */
 
     /**
      * @inheritdoc ERC165

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -71,7 +71,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }
-        
+
         for (uint256 i = 0; i < dataKeys.length; i = _uncheckedIncrement(i)) {
             _setData(dataKeys[i], dataValues[i]);
         }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -12,6 +12,8 @@ import {OwnableUnset} from "./custom/OwnableUnset.sol";
 // constants
 import {_INTERFACEID_ERC725Y} from "./constants.sol";
 
+import "./errors.sol";
+
 /**
  * @title Core implementation of ERC725Y General data key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -66,7 +68,10 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         virtual
         onlyOwner
     {
-        require(dataKeys.length == dataValues.length, "Keys length not equal to values length");
+        if (dataKeys.length != dataValues.length) {
+            revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
+        }
+        
         for (uint256 i = 0; i < dataKeys.length; i = _uncheckedIncrement(i)) {
             _setData(dataKeys[i], dataValues[i]);
         }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -18,8 +18,8 @@ abstract contract ERC725YInitAbstract is Initializable, ERC725YCore {
         internal
         virtual
         onlyInitializing
-        notZeroAddressAsOwner(newOwner)
     {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
 }

--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 bytes4 constant _INTERFACEID_ERC725X = 0x44c028fe;
 bytes4 constant _INTERFACEID_ERC725Y = 0x714df77c;
 
-// ERC725X OPERATIONS TYPES
+// ERC725X OPERATION TYPES
 enum OPERATION_TYPE {
     CALL,
     CREATE,

--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -6,13 +6,11 @@ bytes4 constant _INTERFACEID_ERC725X = 0x44c028fe;
 bytes4 constant _INTERFACEID_ERC725Y = 0x714df77c;
 
 // ERC725X OPERATION TYPES
-enum OPERATION_TYPE {
-    CALL,
-    CREATE,
-    CREATE2,
-    STATICCALL,
-    DELEGATECALL
-}
+uint256 constant OPERATION_0_CALL = 0;
+uint256 constant OPERATION_1_CREATE = 1;
+uint256 constant OPERATION_2_CREATE2 = 2;
+uint256 constant OPERATION_3_STATICCALL = 3;
+uint256 constant OPERATION_4_DELEGATECALL = 4;
 
 // ERC725Y overloaded function selectors
 bytes4 constant SETDATA_SELECTOR = bytes4(keccak256("setData(bytes32,bytes)"));

--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// >> ERC165 INTERFACE IDs
-
-// ERC725 - Smart Contract based Account
+// ERC165 INTERFACE IDs
 bytes4 constant _INTERFACEID_ERC725X = 0x44c028fe;
 bytes4 constant _INTERFACEID_ERC725Y = 0x714df77c;
 
-// >> ERC725X OPERATIONS TYPES
-uint256 constant OPERATION_CALL = 0;
-uint256 constant OPERATION_CREATE = 1;
-uint256 constant OPERATION_CREATE2 = 2;
-uint256 constant OPERATION_STATICCALL = 3;
-uint256 constant OPERATION_DELEGATECALL = 4;
+// ERC725X OPERATIONS TYPES
+enum OPERATION_TYPE {
+    CALL,
+    CREATE,
+    CREATE2,
+    STATICCALL,
+    DELEGATECALL
+}
 
 // ERC725Y overloaded function selectors
 bytes4 constant SETDATA_SELECTOR = bytes4(keccak256("setData(bytes32,bytes)"));

--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -29,17 +29,6 @@ abstract contract OwnableUnset {
     }
 
     /**
-     * @dev disallow passing address(0) as parameter
-     *      intended to be used when setting initial contract owner on deployment
-     *
-     * @param newOwner the address of the contract owner
-     */
-    modifier notZeroAddressAsOwner(address newOwner) {
-        require(newOwner != address(0), "Ownable: contract owner cannot be the zero address");
-        _;
-    }
-
-    /**
      * @dev Leaves the contract without owner. It will not be possible to call
      * `onlyOwner` functions anymore. Can only be called by the current owner.
      *

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -39,7 +39,7 @@ error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
 error ERC725X_ContractDeploymentFailed();
 
 /**
- * @dev reverts when no contract bytecode was provided as parameter when trying to deploy a contract 
+ * @dev reverts when no contract bytecode was provided as parameter when trying to deploy a contract
  * via `ERC725X.execute(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
  */
 error ERC725X_NoContractBytecodeProvided();

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @dev reverts when trying to send more native tokens `value` than available in current `balance`.
+ * @param balance the balance of the ERC725X contract.
+ * @param value the amount of native tokens sent via `ERC725X.execute(...)`.
+ */
+error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
+
+/**
+ * @dev reverts when the `operationTypeProvided` is none of the default operation types available.
+ * (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
+ */
+error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
+
+/**
+ * @dev the `value` parameter (= sending native tokens) is not allowed when making a staticcall
+ * via `ERC725X.execute(...)` because sending native tokens is a state changing operation.
+ */
+error ERC725X_MsgValueDisallowedInStaticCall();
+
+/**
+ * @dev the `value` parameter (= sending native tokens) is not allowed when making a delegatecall
+ * via `ERC725X.execute(...)` because msg.value is persisting.
+ */
+error ERC725X_MsgValueDisallowedInDelegateCall();
+
+/**
+ * @dev reverts when passing a `to` address while deploying a contract va `ERC725X.execute(...)`
+ * whether using operation type 1 (CREATE) or 2 (CREATE2).
+ */
+error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
+
+/**
+ * @dev reverts when contract deployment via `ERC725X.execute(...)` failed.
+ * whether using operation type 1 (CREATE) or 2 (CREATE2).
+ */
+error ERC725X_ContractDeploymentFailed();
+
+/**
+ * @dev reverts when no contract bytecode was provided as parameter when trying to deploy a contract 
+ * via `ERC725X.execute(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
+ */
+error ERC725X_NoContractBytecodeProvided();
+
+/**
+ * @dev reverts when there is not the same number of elements in the lists of data keys and data values
+ * when calling setData(bytes32[],bytes[]).
+ * @param dataKeysLength the number of data keys in the bytes32[] dataKeys
+ * @param dataValuesLength the number of data value in the bytes[] dataValue
+ */
+error ERC725Y_DataKeysValuesLengthMismatch(uint256 dataKeysLength, uint256 dataValuesLength);

--- a/implementations/contracts/helpers/Reader.sol
+++ b/implementations/contracts/helpers/Reader.sol
@@ -14,7 +14,7 @@ contract Reader {
      * @dev do not put the `view` modifier, so to display the gas usage of `getData(...)`
      *  in the gas reporter of the test suite
      */
-    function read(bytes32 _key) public returns (bytes memory) {
+    function read(bytes32 _key) public view returns (bytes memory) {
         bytes32[] memory keys = new bytes32[](1);
         keys[0] = _key;
 

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -42,15 +42,15 @@ interface IERC725X is IERC165 {
      * @param to The smart contract or address to interact with (unused if a contract is created via operation 1 or 2)
      * @param value The amount of native tokens to transfer (in Wei).
      * @param data The call data, or the bytecode of the contract to deploy
-     * 
+     *
      * @dev Generic executor function to:
-     * 
+     *
      * - send native tokens to any address.
      * - interact with any contract by passing an abi-encoded function call in the `data` parameter.
      * - deploy a contract by providing its bytecode via the `data` parameter
-     * 
+     *
      * Requirements:
-     * 
+     *
      * - SHOULD only be callable by the owner of the contract set via ERC173.
      * - if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
      * - `to` SHOULD be address(0) when deploying a contract.

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -41,13 +41,13 @@ interface IERC725X is IERC165 {
      * @param operationType The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4
      * @param to The address of the EOA or smart contract to (unused if a contract is created via operation type 1 or 2)
      * @param value The amount of native tokens to transfer (in Wei)
-     * @param data The call data, or the bytecode of the contract to deploy
+     * @param data The call data, or the creation bytecode of the contract to deploy (constructor + runtime code)
      *
      * @dev Generic executor function to:
      *
      * - send native tokens to any address.
      * - interact with any contract by passing an abi-encoded function call in the `data` parameter.
-     * - deploy a contract by providing its bytecode via the `data` parameter
+     * - deploy a contract by providing its creation bytecode in the `data` parameter.
      *
      * Requirements:
      *

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -12,22 +12,22 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  */
 interface IERC725X is IERC165 {
     /**
-     * @notice Emitted when a contract is created
-     * @param operation The operation used to create a contract
+     * @notice Emitted when deploying a contract
+     * @param operationType The opcode used to deploy the contract (CREATE or CREATE2)
      * @param contractAddress The created contract address
-     * @param value The amount of native tokens (in Wei) sent to the created contract address
+     * @param value The amount of native tokens (in Wei) sent to fund the created contract address
      */
     event ContractCreated(
-        uint256 indexed operation,
+        uint256 indexed operationType,
         address indexed contractAddress,
         uint256 indexed value
     );
 
     /**
-     * @notice Emitted when a contract executed.
-     * @param operationType The operation used to execute a contract
-     * @param to The address where the call is executed
-     * @param value The amount of native tokens transferred with the call (in Wei).
+     * @notice Emitted when calling an address (EOA or contract)
+     * @param operationType The low-level call opcode used to call the `to` address (CALL, STATICALL or DELEGATECALL)
+     * @param to The address to call whether an EOA or a contract
+     * @param value The amount of native tokens transferred with the call (in Wei)
      * @param selector The first 4 bytes (= function selector) of the data sent with the call
      */
     event Executed(
@@ -38,9 +38,9 @@ interface IERC725X is IERC165 {
     );
 
     /**
-     * @param operationType The operation to execute: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4
-     * @param to The smart contract or address to interact with (unused if a contract is created via operation 1 or 2)
-     * @param value The amount of native tokens to transfer (in Wei).
+     * @param operationType The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4
+     * @param to The address of the EOA or smart contract to (unused if a contract is created via operation type 1 or 2)
+     * @param value The amount of native tokens to transfer (in Wei)
      * @param data The call data, or the bytecode of the contract to deploy
      *
      * @dev Generic executor function to:
@@ -55,8 +55,8 @@ interface IERC725X is IERC165 {
      * - if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
      * - `to` SHOULD be address(0) when deploying a contract.
      *
-     * Emits an {Executed} event, when a call is executed under `operationType` 0, 3 and 4
-     * Emits a {ContractCreated} event, when a contract is created under `operationType` 1 and 2
+     * Emits an {Executed} event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL)
+     * Emits a {ContractCreated} event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
      */
     function execute(
         uint256 operationType,

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -25,20 +25,20 @@ interface IERC725X is IERC165 {
 
     /**
      * @notice Emitted when a contract executed.
-     * @param operation The operation used to execute a contract
+     * @param operationType The operation used to execute a contract
      * @param to The address where the call is executed
      * @param value The amount of native tokens transferred with the call (in Wei).
      * @param selector The first 4 bytes (= function selector) of the data sent with the call
      */
     event Executed(
-        uint256 indexed operation,
+        uint256 indexed operationType,
         address indexed to,
         uint256 indexed value,
         bytes4 selector
     );
 
     /**
-     * @param operationType The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3 DELEGATECALL = 4
+     * @param operationType The operation to execute: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4
      * @param to The smart contract or address to interact with (unused if a contract is created via operation 1 or 2)
      * @param value The amount of native tokens to transfer (in Wei).
      * @param data The call data, or the bytecode of the contract to deploy
@@ -53,7 +53,7 @@ interface IERC725X is IERC165 {
      * 
      * - SHOULD only be callable by the owner of the contract set via ERC173.
      * - if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
-     *  `to` SHOULD be address(0) when deploying a contract.
+     * - `to` SHOULD be address(0) when deploying a contract.
      *
      * Emits an {Executed} event, when a call is executed under `operationType` 0, 3 and 4
      * Emits a {ContractCreated} event, when a contract is created under `operationType` 1 and 2

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -41,7 +41,7 @@ interface IERC725X is IERC165 {
      * @param operationType The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4
      * @param to The address of the EOA or smart contract to (unused if a contract is created via operation type 1 or 2)
      * @param value The amount of native tokens to transfer (in Wei)
-     * @param data The call data, or the creation bytecode of the contract to deploy (constructor + runtime code)
+     * @param data The call data, or the creation bytecode of the contract to deploy
      *
      * @dev Generic executor function to:
      *

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -39,13 +39,23 @@ interface IERC725X is IERC165 {
 
     /**
      * @param operationType The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3 DELEGATECALL = 4
-     * @param to The smart contract or address to interact with, `to` will be unused if a contract is created (operation 1 and 2)
+     * @param to The smart contract or address to interact with (unused if a contract is created via operation 1 or 2)
      * @param value The amount of native tokens to transfer (in Wei).
      * @param data The call data, or the bytecode of the contract to deploy
-     * @dev Executes any other smart contract.
-     * SHOULD only be callable by the owner of the contract set via ERC173
+     * 
+     * @dev Generic executor function to:
+     * 
+     * - send native tokens to any address.
+     * - interact with any contract by passing an abi-encoded function call in the `data` parameter.
+     * - deploy a contract by providing its bytecode via the `data` parameter
+     * 
+     * Requirements:
+     * 
+     * - SHOULD only be callable by the owner of the contract set via ERC173.
+     * - if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+     *  `to` SHOULD be address(0) when deploying a contract.
      *
-     * Emits a {Executed} event, when a call is executed under `operationType` 0, 3 and 4
+     * Emits an {Executed} event, when a call is executed under `operationType` 0, 3 and 4
      * Emits a {ContractCreated} event, when a contract is created under `operationType` 1 and 2
      */
     function execute(

--- a/implementations/hardhat.config.ts
+++ b/implementations/hardhat.config.ts
@@ -33,6 +33,14 @@ const config: HardhatUserConfig = {
     outDir: "types",
     target: "ethers-v5",
   },
+  gasReporter: {
+    enabled: true,
+    currency: "USD",
+    gasPrice: 21,
+    excludeContracts: ["helpers/"],
+    src: "./contracts",
+    showMethodSig: true,
+  }
 };
 
 export default config;

--- a/implementations/test/ERC725.test.ts
+++ b/implementations/test/ERC725.test.ts
@@ -18,7 +18,7 @@ type ERC725TestContext = {
   deployParams: ERC725DeployParams;
 };
 
-describe.only("ERC725", () => {
+describe("ERC725", () => {
   describe("when using ERC725 with constructor", () => {
     describe("when deploying the contract", () => {
       it("should revert when giving address(0) as owner", async () => {

--- a/implementations/test/ERC725.test.ts
+++ b/implementations/test/ERC725.test.ts
@@ -31,7 +31,7 @@ describe("ERC725", () => {
         await expect(
           new ERC725__factory(accounts[0]).deploy(deployParams.newOwner)
         ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
+          "Ownable: new owner is the zero address"
         );
       });
     });
@@ -78,7 +78,7 @@ describe("ERC725", () => {
         await expect(
           context.erc725["initialize(address)"](ethers.constants.AddressZero)
         ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
+          "Ownable: new owner is the zero address"
         );
       });
     });

--- a/implementations/test/ERC725.test.ts
+++ b/implementations/test/ERC725.test.ts
@@ -18,7 +18,7 @@ type ERC725TestContext = {
   deployParams: ERC725DeployParams;
 };
 
-describe("ERC725", () => {
+describe.only("ERC725", () => {
   describe("when using ERC725 with constructor", () => {
     describe("when deploying the contract", () => {
       it("should revert when giving address(0) as owner", async () => {
@@ -27,6 +27,8 @@ describe("ERC725", () => {
         const deployParams = {
           newOwner: ethers.constants.AddressZero,
         };
+
+        const contract = await new ERC725__factory(accounts[0]).deploy(accounts[0].address)
 
         await expect(
           new ERC725__factory(accounts[0]).deploy(deployParams.newOwner)

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -501,6 +501,8 @@ export const shouldBehaveLikeERC725X = (
               data: "0x",
             };
 
+            const contractBalance = await provider.getBalance(context.erc725X.address)
+
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
@@ -510,7 +512,10 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance");
+            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_InsufficientBalance").withArgs(
+              contractBalance,
+              ethers.utils.parseEther("75")
+            );
           });
         });
       });
@@ -953,7 +958,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: Could not deploy contract");
+            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_ContractDeploymentFailed");
           });
         });
 
@@ -975,8 +980,9 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith(
-              "ERC725X: CREATE operations require the receiver address to be empty"
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_CreateOperationsRequireEmptyRecipientAddress"
             );
           });
         });
@@ -1043,6 +1049,8 @@ export const shouldBehaveLikeERC725X = (
               data: WithConstructorPayableContractBytecode,
             };
 
+            const contractBalance = await provider.getBalance(context.erc725X.address)
+
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
@@ -1052,7 +1060,13 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance");
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_InsufficientBalance"
+            ).withArgs(
+              contractBalance,
+              ethers.utils.parseEther("90")
+            );
           });
         });
 
@@ -1074,7 +1088,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: Could not deploy contract");
+            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_ContractDeploymentFailed");
           });
         });
       });
@@ -1325,8 +1339,8 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith(
-              "ERC725X: CREATE operations require the receiver address to be empty"
+            ).to.be.revertedWithCustomError(
+              context.erc725X, "ERC725X_CreateOperationsRequireEmptyRecipientAddress"
             );
           });
         });
@@ -1406,7 +1420,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith("ERC725X: insufficient balance");
+            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_InsufficientBalance");
           });
         });
 
@@ -1612,8 +1626,9 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith(
-              "ERC725X: cannot transfer value with operation STATICCALL"
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_MsgValueDisallowedInStaticCall"
             );
           });
         });
@@ -1783,8 +1798,9 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWith(
-              "ERC725X: cannot transfer value with operation DELEGATECALL"
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_MsgValueDisallowedInDelegateCall"
             );
           });
         });
@@ -1918,7 +1934,7 @@ export const shouldBehaveLikeERC725X = (
               txParams.value,
               txParams.data
             )
-        ).to.be.revertedWith("ERC725X: Unknown operation type");
+        ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_UnknownOperationType");
       });
     });
   });

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -785,6 +785,28 @@ export const shouldBehaveLikeERC725X = (
 
     describe("When testing Operation CREATE", () => {
       describe("When creating a contract", () => {
+        describe("without passing the contract deployment code", () => {
+          it("should revert", async () => {
+            const txParams = {
+              Operation: OPERATION_TYPE.CREATE,
+              to: AddressZero,
+              value: 0,
+              data: "0x",
+            };
+
+            await expect(
+              context.erc725X
+                .connect(context.accounts.owner)
+                .execute(
+                  txParams.Operation,
+                  txParams.to,
+                  txParams.value,
+                  txParams.data
+                )
+            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_NoContractBytecodeProvided");
+          })
+        })
+
         describe("without constructor", () => {
           it("should create the contract and emit ContractCreated event", async () => {
             const txParams = {

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -501,7 +501,9 @@ export const shouldBehaveLikeERC725X = (
               data: "0x",
             };
 
-            const contractBalance = await provider.getBalance(context.erc725X.address)
+            const contractBalance = await provider.getBalance(
+              context.erc725X.address
+            );
 
             await expect(
               context.erc725X
@@ -512,10 +514,12 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_InsufficientBalance").withArgs(
-              contractBalance,
-              ethers.utils.parseEther("75")
-            );
+            )
+              .to.be.revertedWithCustomError(
+                context.erc725X,
+                "ERC725X_InsufficientBalance"
+              )
+              .withArgs(contractBalance, ethers.utils.parseEther("75"));
           });
         });
       });
@@ -958,7 +962,10 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_ContractDeploymentFailed");
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_ContractDeploymentFailed"
+            );
           });
         });
 
@@ -1049,7 +1056,9 @@ export const shouldBehaveLikeERC725X = (
               data: WithConstructorPayableContractBytecode,
             };
 
-            const contractBalance = await provider.getBalance(context.erc725X.address)
+            const contractBalance = await provider.getBalance(
+              context.erc725X.address
+            );
 
             await expect(
               context.erc725X
@@ -1060,13 +1069,12 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWithCustomError(
-              context.erc725X,
-              "ERC725X_InsufficientBalance"
-            ).withArgs(
-              contractBalance,
-              ethers.utils.parseEther("90")
-            );
+            )
+              .to.be.revertedWithCustomError(
+                context.erc725X,
+                "ERC725X_InsufficientBalance"
+              )
+              .withArgs(contractBalance, ethers.utils.parseEther("90"));
           });
         });
 
@@ -1088,7 +1096,10 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_ContractDeploymentFailed");
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_ContractDeploymentFailed"
+            );
           });
         });
       });
@@ -1340,7 +1351,8 @@ export const shouldBehaveLikeERC725X = (
                   txParams.data
                 )
             ).to.be.revertedWithCustomError(
-              context.erc725X, "ERC725X_CreateOperationsRequireEmptyRecipientAddress"
+              context.erc725X,
+              "ERC725X_CreateOperationsRequireEmptyRecipientAddress"
             );
           });
         });
@@ -1420,7 +1432,10 @@ export const shouldBehaveLikeERC725X = (
                   txParams.value,
                   txParams.data
                 )
-            ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_InsufficientBalance");
+            ).to.be.revertedWithCustomError(
+              context.erc725X,
+              "ERC725X_InsufficientBalance"
+            );
           });
         });
 
@@ -1934,7 +1949,10 @@ export const shouldBehaveLikeERC725X = (
               txParams.value,
               txParams.data
             )
-        ).to.be.revertedWithCustomError(context.erc725X, "ERC725X_UnknownOperationType");
+        ).to.be.revertedWithCustomError(
+          context.erc725X,
+          "ERC725X_UnknownOperationType"
+        );
       });
     });
   });

--- a/implementations/test/ERC725X.test.ts
+++ b/implementations/test/ERC725X.test.ts
@@ -38,7 +38,7 @@ describe("ERC725X", () => {
         await expect(
           new ERC725X__factory(accounts.owner).deploy(deployParams.newOwner)
         ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
+          "Ownable: new owner is the zero address"
         );
       });
 
@@ -119,7 +119,7 @@ describe("ERC725X", () => {
         await expect(
           context.erc725X["initialize(address)"](ethers.constants.AddressZero)
         ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
+          "Ownable: new owner is the zero address"
         );
       });
 

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -627,7 +627,8 @@ export const shouldBehaveLikeERC725Y = (
                   [txParams.dataKey, txParams.dataKey],
                   [txParams.dataValue]
                 )
-            ).to.be.revertedWith("Keys length not equal to values length");
+            ).to.be.revertedWithCustomError(context.erc725Y, "ERC725Y_DataKeysValuesLengthMismatch")
+              .withArgs(2, 1);
           });
         });
       });

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -627,7 +627,11 @@ export const shouldBehaveLikeERC725Y = (
                   [txParams.dataKey, txParams.dataKey],
                   [txParams.dataValue]
                 )
-            ).to.be.revertedWithCustomError(context.erc725Y, "ERC725Y_DataKeysValuesLengthMismatch")
+            )
+              .to.be.revertedWithCustomError(
+                context.erc725Y,
+                "ERC725Y_DataKeysValuesLengthMismatch"
+              )
               .withArgs(2, 1);
           });
         });

--- a/implementations/test/ERC725Y.test.ts
+++ b/implementations/test/ERC725Y.test.ts
@@ -44,7 +44,7 @@ describe("ERC725Y", () => {
         await expect(
           new ERC725Y__factory(accounts.owner).deploy(deployParams.newOwner)
         ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
+          "Ownable: new owner is the zero address"
         );
       });
 
@@ -119,7 +119,7 @@ describe("ERC725Y", () => {
         await expect(
           context.erc725Y["initialize(address)"](ethers.constants.AddressZero)
         ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
+          "Ownable: new owner is the zero address"
         );
       });
 


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor & Perfs 🚀 (⚠️ BREAKING CHANGES)

- ⚠️ replace revert reason strings by custom errors in `ERC725XCore` and `ERC725YCore`. All errors are listed in `errors.sol`.

This reduces the deployment cost of the contracts by around 200,00 gas. See table summary below.

- ⚠️  rename the `uint256` constants for each OPERATION_TYPE by adding the operation number inside the constant name. `OPERATION_CALL` -> `OPERATION_0_CALL`.

- remove modifier to inline owner is not zero address check inside constructor / initializer.

## 🎨 Style

- delete comments that aim to create sections _e.g: public functions, internal functions, overriden functions, etc...)_. Remove these comments in favour of following the Solidity style guide: 

## 📝 Docs

- added Natspec comments for newly created custom errors.
- improve descriptions of existing Natspec docs comments + descriptions of `execute(...)` method in ERC725.md
    - replace `operation` -> `operationType`.
    - specify "low-level" for call operations + "opcode" for contract creation operations.
operationType
    - add "Requirements" section with bullet points under the `execute(...)` function in the `IERC725X` interface contract.
    - change variable name from `data` to `creationCode` for contract deployment internal methods.
    
## 🧪 Tests

- edit all revert reason strings with custom errors.

## 🏗️ Build

- add configs for Hardhat gas reporter.

# Gas Cost improvements

## Deployment Cost

| Contract | Deployment cost before  | Deployment cost after  |  Change (in gas) | Change (in %) |
|---------------|---|---|---|---|
| `ERC725Init`  | 2_554_139  | 2_285_509  | 📉 -268_630 | 📉 -10.52% |
|  `ERC725` |   |  2_075_156 |   |   |
| `ERC725X`    | 1_714_827  | 1_507_680  | 📉 -207_147 | 📉 -12.08% |
| `ERC725XInit`  | 1_956_761  | 1_718_059  | 📉 -238_702 | 📉 -12.20% |
| `ERC725Y`  |  1_084_771 | 1_068_904 | 📉 -15_867 |  📉 -1.46% |
| `ERC725YInit`  | 1_323_811  | 1_276_413  | 📉 -47_398 |  📉 -3.60% |

## Execution Cost

|  Contract  | Method | Gas cost (average) before | Gas cost (average) after | change (in gas) | change (in %) |
|-----------|---------|---------------------------|--------------------------|----------------|---------------|
| `ERC725` | `execute(uint256,address,uint256,bytes)` | 50_903 |  50_720 | 📉 -183 | 📉 -0.36% |
| `ERC725` | `setData(bytes32,bytes)` | 1_468_353  | 1_330_410  | 📉 -137_943 | 📉 -9.39% |
| `ERC725` | `setData (bytes32[],bytes[])` |  1_393_483 | 1_263_203  | 📉 -130_280 | 📉 -9.35% |
| `ERC725X` | `execute(uint256,address,uint256,bytes)` | 48_141  | 47_958  | 📉 -183  | 📉 -0.38%%  |
| `ERC725Y` | `setData (bytes32, bytes)` | 1_465_204  |  1_327_305 | 📉 -137_899  | 📉 -9.41% |
| `ERC725Y` | `setData (bytes32[],bytes[])` | 1_390_330 | 1_260_092 | 📉 -130_238 | 📉 -9.37%  |
