### PR TITLE
refactor!: add `salt` parameter to the `ContractCreated` event in ERC725X

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -52,7 +52,7 @@ Smart contracts implementing the ERC725X standard SHOULD implement all of the fu
 #### execute
 
 ```solidity
-function execute(uint256 operationType, address target, uint256 value, bytes memory data) public payable returns(bytes memory)
+function execute(uint256 operationType, address target, uint256 value, bytes memory data) external payable returns(bytes memory)
 ```
 
 Function Selector: `0x44c028fe`
@@ -109,7 +109,7 @@ data = <contract-creation-code> + <abi-encoded-constructor-arguments> + <bytes32
 #### execute (Array)
 
 ```solidity
-function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) public payable returns(bytes[] memory)
+function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory)
 ```
 
 Function Selector: `0x13ced88d`
@@ -191,7 +191,7 @@ Smart contracts implementing the ERC725Y standard MUST implement all of the func
 #### getData
 
 ```solidity
-function getData(bytes32 dataKey) public view returns(bytes memory)
+function getData(bytes32 dataKey) external view returns(bytes memory)
 ```
 
 Function Selector: `0x54f6127f`
@@ -207,7 +207,7 @@ _Returns:_ `bytes` , The data for the requested data key.
 #### getData (Array)
 
 ```solidity
-function getData(bytes32[] memory dataKeys) public view returns(bytes[] memory)
+function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory)
 ```
 
 Function Selector: `0x4e3e6e9c`
@@ -223,7 +223,7 @@ _Returns:_ `bytes[]` , array of data values for the requested data keys.
 #### setData
 
 ```solidity
-function setData(bytes32 dataKey, bytes memory dataValue) public
+function setData(bytes32 dataKey, bytes memory dataValue) external
 ```
 
 Function Selector: `0x7f23690c`
@@ -244,7 +244,7 @@ _Requirements:_
 #### setData (Array)
 
 ```solidity
-function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public
+function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external
 ```
 
 Function Selector: `0x14a6e293`
@@ -328,7 +328,7 @@ pragma solidity >=0.5.0 <0.7.0;
 
 // ERC165 identifier: `0x570ef073`
 interface IERC725X  /* is ERC165, ERC173 */ {
-    event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value);
+    event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
     event Executed(uint256 indexed operationType, address indexed target, uint256 indexed  value, bytes4 data);
 
     function execute(uint256 operationType, address target, uint256 value, bytes memory data) external payable returns(bytes memory);

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -219,7 +219,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         }
 
         newContract = abi.encodePacked(contractAddress);
-        emit ContractCreated(OPERATION_1_CREATE, contractAddress, value);
+        emit ContractCreated(OPERATION_1_CREATE, contractAddress, value, bytes32(0));
     }
 
     /**
@@ -242,7 +242,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         address contractAddress = Create2.deploy(value, salt, bytecode);
 
         newContract = abi.encodePacked(contractAddress);
-        emit ContractCreated(OPERATION_2_CREATE2, contractAddress, value);
+        emit ContractCreated(OPERATION_2_CREATE2, contractAddress, value, salt);
     }
 
     /**

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -20,7 +20,8 @@ interface IERC725X is IERC165 {
     event ContractCreated(
         uint256 indexed operationType,
         address indexed contractAddress,
-        uint256 indexed value
+        uint256 indexed value,
+        bytes32 salt
     );
 
     /**

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -855,7 +855,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  "0x" + "0".repeat(64)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -913,7 +914,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  "0x" + "0".repeat(64)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -962,7 +964,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  "0x" + "0".repeat(64)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1064,7 +1067,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  "0x" + "0".repeat(64)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1179,7 +1183,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  salt
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1241,7 +1246,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  salt
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1294,7 +1300,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  salt
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1431,7 +1438,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  salt
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1542,7 +1550,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operation,
                   addressContractCreatedChecksumed,
-                  txParams.value
+                  txParams.value,
+                  salt
                 );
 
               const codeRetreived = await provider.getCode(
@@ -2275,7 +2284,8 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operations[1],
                   contractAddress,
-                  txParams.values[1]
+                  txParams.values[1],
+                  "0x" + "0".repeat(64)
                 );
 
               const codeOfContractCreated = await provider.getCode(
@@ -2400,13 +2410,15 @@ export const shouldBehaveLikeERC725X = (
                 .withArgs(
                   txParams.Operations[0],
                   ethers.utils.getAddress(contractsAddresses[0]),
-                  txParams.values[0]
+                  txParams.values[0],
+                  "0x" + "0".repeat(64)
                 )
                 .to.emit(context.erc725X, "ContractCreated")
                 .withArgs(
                   txParams.Operations[1],
                   ethers.utils.getAddress(contractsAddresses[1]),
-                  txParams.values[1]
+                  txParams.values[1],
+                  "0x" + "0".repeat(64)
                 );
 
               const codeOfContractCreated1 = await provider.getCode(

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -856,7 +856,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.Operation,
                   addressContractCreatedChecksumed,
                   txParams.value,
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -915,7 +915,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.Operation,
                   addressContractCreatedChecksumed,
                   txParams.value,
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -965,7 +965,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.Operation,
                   addressContractCreatedChecksumed,
                   txParams.value,
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -1068,7 +1068,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.Operation,
                   addressContractCreatedChecksumed,
                   txParams.value,
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 );
 
               const codeRetreived = await provider.getCode(
@@ -2285,7 +2285,7 @@ export const shouldBehaveLikeERC725X = (
                   txParams.Operations[1],
                   contractAddress,
                   txParams.values[1],
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 );
 
               const codeOfContractCreated = await provider.getCode(
@@ -2411,14 +2411,14 @@ export const shouldBehaveLikeERC725X = (
                   txParams.Operations[0],
                   ethers.utils.getAddress(contractsAddresses[0]),
                   txParams.values[0],
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 )
                 .to.emit(context.erc725X, "ContractCreated")
                 .withArgs(
                   txParams.Operations[1],
                   ethers.utils.getAddress(contractsAddresses[1]),
                   txParams.values[1],
-                  "0x" + "0".repeat(64)
+                  ethers.utils.hexZeroPad("0x00", 32)
                 );
 
               const codeOfContractCreated1 = await provider.getCode(


### PR DESCRIPTION
## What does this PR introduce?
-  add `salt` parameter to the `ContractCreated` event in ERC725X
-  add tests
- adjust the specs accordingly
