### PR TITLE
refactor!: mark `setData(..)` as payable

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -21,7 +21,7 @@ The initial motivation came out of the need to create a smart contract account s
 
 This standard consists of two sub standards, a generic data key/value store (ERC725Y) and a generic execute function (ERC725X). Both of which in combination allow for a very flexible and long lasting account system. The account version of ERC725 is standardised under [LSP0 ERC725Account](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-0-ERC725Account.md).
 
-These standareds (ERC725 X and Y) can also be used seperately to enhance NFTs and Token meta data or other types of smart contracts. ERC725X allows for a  generic exection through a smart contract, functioning as an account or actor.
+These standareds (ERC725 X and Y) can also be used seperately to enhance NFTs and Token meta data or other types of smart contracts. ERC725X allows for a generic exection through a smart contract, functioning as an account or actor.
 
 ## Specification
 
@@ -59,7 +59,6 @@ Function Selector: `0x44c028fe`
 
 Executes a call on any other smart contracts or address, transfers the blockchains native token, or deploys a new smart contract.
 
-
 _Parameters:_
 
 - `operationType`: the operation type used to execute.
@@ -67,14 +66,12 @@ _Parameters:_
 - `value`: the amount of native tokens to transfer (in Wei).
 - `data`: the call data, or the creation bytecode of the contract to deploy.
 
-
 _Requirements:_
 
 - MUST only be called by the current owner of the contract.
 - MUST revert when the execution or the contract creation fails.
 - `target` SHOULD be address(0) in case of contract creation with `CREATE` and `CREATE2` (operation types 1 and 2).
 - `value` SHOULD be zero in case of `STATICCALL` or `DELEGATECALL` (operation types 3 and 4).
-
 
 _Returns:_ `bytes` , the returned data of the called function, or the address of the contract deployed (operation types 1 and 2).
 
@@ -137,7 +134,6 @@ _Returns:_ `bytes[]` , array list of returned data of the called function, or th
 
 **Triggers Event:** [ContractCreated](#contractcreated), [Executed](#executed) on each call iteration
 
-
 **Note:** The `execute()` functions use function overloading, therefore it is better to reference them by the given function signature as follows:
 
 ```js
@@ -146,7 +142,7 @@ _Returns:_ `bytes[]` , array list of returned data of the called function, or th
 // execute
 myContract.methods['execute(uint256,address,uint256,bytes)'](OPERATION_CALL, target.address, 2WEI, "0x").send();
 
-// execute Array 
+// execute Array
 myContract.methods['execute(uint256[],address[],uint256[],bytes[])']([OPERATION_CALL, OPERATION_CREATE], [target.address, ZERO_ADDRESS], [2WEI, 0WEI], ["0x", CONTRACT_BYTECODE]).send()
 
 // OR
@@ -154,7 +150,7 @@ myContract.methods['execute(uint256[],address[],uint256[],bytes[])']([OPERATION_
 // execute
 myContract.methods['0x44c028fe'](OPERATION_CALL, target.address, 2WEI, "0x").send();
 
-// execute Array 
+// execute Array
 myContract.methods['0x13ced88d']([OPERATION_CALL, OPERATION_CREATE], [target.address, ZERO_ADDRESS], [2WEI, 0WEI], ["0x", CONTRACT_BYTECODE]).send()
 ```
 
@@ -223,12 +219,12 @@ _Returns:_ `bytes[]` , array of data values for the requested data keys.
 #### setData
 
 ```solidity
-function setData(bytes32 dataKey, bytes memory dataValue) external
+function setData(bytes32 dataKey, bytes memory dataValue) external payable
 ```
 
 Function Selector: `0x7f23690c`
 
-Sets data as bytes in the storage for a single data key. 
+Sets data as bytes in the storage for a single data key.
 
 _Parameters:_
 
@@ -244,7 +240,7 @@ _Requirements:_
 #### setData (Array)
 
 ```solidity
-function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external
+function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable
 ```
 
 Function Selector: `0x14a6e293`
@@ -366,6 +362,4 @@ interface IERC725 /* is IERC725X, IERC725Y */ {
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-
-
-[ERC165]: <https://eips.ethereum.org/EIPS/eip-165>
+[erc165]: https://eips.ethereum.org/EIPS/eip-165

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -30,20 +30,18 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function getData(bytes32 dataKey) public view virtual override returns (bytes memory dataValue) {
+    function getData(
+        bytes32 dataKey
+    ) public view virtual override returns (bytes memory dataValue) {
         dataValue = _getData(dataKey);
     }
 
     /**
      * @inheritdoc IERC725Y
      */
-    function getData(bytes32[] memory dataKeys)
-        public
-        view
-        virtual
-        override
-        returns (bytes[] memory dataValues)
-    {
+    function getData(
+        bytes32[] memory dataKeys
+    ) public view virtual override returns (bytes[] memory dataValues) {
         dataValues = new bytes[](dataKeys.length);
 
         for (uint256 i = 0; i < dataKeys.length; i = _uncheckedIncrementERC725Y(i)) {
@@ -56,19 +54,23 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function setData(bytes32 dataKey, bytes memory dataValue) public virtual override onlyOwner {
+    function setData(
+        bytes32 dataKey,
+        bytes memory dataValue
+    ) public payable virtual override onlyOwner {
+        if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
         _setData(dataKey, dataValue);
     }
 
     /**
      * @inheritdoc IERC725Y
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
-        public
-        virtual
-        override
-        onlyOwner
-    {
+    function setData(
+        bytes32[] memory dataKeys,
+        bytes[] memory dataValues
+    ) public payable virtual override onlyOwner {
+        if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
+
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }
@@ -100,13 +102,9 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc ERC165
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(IERC165, ERC165)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, ERC165) returns (bool) {
         return interfaceId == _INTERFACEID_ERC725Y || super.supportsInterface(interfaceId);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -69,6 +69,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         bytes32[] memory dataKeys,
         bytes[] memory dataValues
     ) public payable virtual override onlyOwner {
+        /// @dev do not allow to send value by default when setting data in ERC725Y
         if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
 
         if (dataKeys.length != dataValues.length) {

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -56,3 +56,8 @@ error ERC725X_ExecuteParametersLengthMismatch();
  * @param dataValuesLength the number of data value in the bytes[] dataValue
  */
 error ERC725Y_DataKeysValuesLengthMismatch(uint256 dataKeysLength, uint256 dataValuesLength);
+
+/**
+ * @dev reverts when sending value to the `setData(..)` functions
+ */
+error ERC725Y_MsgValueDisallowed();

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -53,7 +53,7 @@ interface IERC725Y is IERC165 {
      * @dev Sets array of data for multiple given `dataKeys`
      * SHOULD only be callable by the owner of the contract set via ERC173
      *
-     * The function was marked as payable to enable flexibility on child contracts
+     * The function is marked as payable to enable flexibility on child contracts
      *
      * If the function is not intended to receive value, an additional check
      * should be implemented to check that value equal 0.

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -38,7 +38,7 @@ interface IERC725Y is IERC165 {
      * @param dataValue The value to set
      * SHOULD only be callable by the owner of the contract set via ERC173
      *
-     * The function was marked as payable to enable flexibility on child contracts
+     * The function is marked as payable to enable flexibility on child contracts
      *
      * If the function is not intended to receive value, an additional check
      * should be implemented to check that value equal 0.

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -38,9 +38,14 @@ interface IERC725Y is IERC165 {
      * @param dataValue The value to set
      * SHOULD only be callable by the owner of the contract set via ERC173
      *
+     * The function was marked as payable to enable flexibility on child contracts
+     *
+     * If the function is not intended to receive value, an additional check
+     * should be implemented to check that value equal 0.
+     *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32 dataKey, bytes memory dataValue) external;
+    function setData(bytes32 dataKey, bytes memory dataValue) external payable;
 
     /**
      * @param dataKeys The array of data keys for values to set
@@ -48,7 +53,12 @@ interface IERC725Y is IERC165 {
      * @dev Sets array of data for multiple given `dataKeys`
      * SHOULD only be callable by the owner of the contract set via ERC173
      *
+     * The function was marked as payable to enable flexibility on child contracts
+     *
+     * If the function is not intended to receive value, an additional check
+     * should be implemented to check that value equal 0.
+     *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable;
 }

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -107,6 +107,27 @@ export const shouldBehaveLikeERC725Y = (
   });
 
   describe("When testing setting data", () => {
+    describe("When sending value to setData", () => {
+      it("should revert when sending value", async () => {
+        let value = 100;
+        const txParams = {
+          dataKey: ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
+          dataValue: "0xaabbccdd",
+        };
+
+        await expect(
+          context.erc725Y
+            .connect(context.accounts.owner)
+            ["setData(bytes32,bytes)"](txParams.dataKey, txParams.dataValue, {
+              value: value,
+            })
+        ).to.be.revertedWithCustomError(
+          context.erc725Y,
+          "ERC725Y_MsgValueDisallowed"
+        );
+      });
+    });
+
     describe("When using setData(bytes32,bytes)", () => {
       describe("When owner is setting data", () => {
         it("should pass and emit DataChanged event", async () => {

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -108,7 +108,7 @@ export const shouldBehaveLikeERC725Y = (
 
   describe("When testing setting data", () => {
     describe("When sending value to setData", () => {
-      it("should revert when sending value", async () => {
+      it("should revert when sending value to setData(..)", async () => {
         let value = 100;
         const txParams = {
           dataKey: ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
@@ -121,6 +121,31 @@ export const shouldBehaveLikeERC725Y = (
             ["setData(bytes32,bytes)"](txParams.dataKey, txParams.dataValue, {
               value: value,
             })
+        ).to.be.revertedWithCustomError(
+          context.erc725Y,
+          "ERC725Y_MsgValueDisallowed"
+        );
+      });
+
+      it("should revert when sending value to setData(..) Array", async () => {
+        let value = 100;
+        const txParams = {
+          dataKey: [
+            ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
+          ],
+          dataValue: ["0xaabbccdd"],
+        };
+
+        await expect(
+          context.erc725Y
+            .connect(context.accounts.owner)
+            ["setData(bytes32[],bytes[])"](
+              txParams.dataKey,
+              txParams.dataValue,
+              {
+                value: value,
+              }
+            )
         ).to.be.revertedWithCustomError(
           context.erc725Y,
           "ERC725Y_MsgValueDisallowed"


### PR DESCRIPTION
## What does this PR introduce?

## BREAKING CHANGE ⚠️ ⚠️ 

- mark `setData(..)` as payable
- Add tests for reverting when sending value