### PR TITLE
fix: add check for empty array parameters in batch `ERC725X.execute(uint256[],address[],uint256[],bytes[])` / `ERC725Y.setData(bytes32[],bytes[])`

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -131,16 +131,15 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes[] memory datas
     ) internal virtual returns (bytes[] memory) {
         if (
-            operationsType.length == 0 ||
-            targets.length == 0 ||
-            values.length == 0 ||
-            datas.length == 0
-        ) revert ERC725X_ExecuteParametersEmptyArray();
-
-        if (
             operationsType.length != targets.length ||
             (targets.length != values.length || values.length != datas.length)
-        ) revert ERC725X_ExecuteParametersLengthMismatch();
+        ) {
+            revert ERC725X_ExecuteParametersLengthMismatch();
+        }
+
+        if (operationsType.length == 0) {
+            revert ERC725X_ExecuteParametersEmptyArray();
+        }
 
         bytes[] memory result = new bytes[](operationsType.length);
 

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -131,6 +131,13 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes[] memory datas
     ) internal virtual returns (bytes[] memory) {
         if (
+            operationsType.length == 0 ||
+            targets.length == 0 ||
+            values.length == 0 ||
+            datas.length == 0
+        ) revert ERC725X_ExecuteParametersEmptyArray();
+
+        if (
             operationsType.length != targets.length ||
             (targets.length != values.length || values.length != datas.length)
         ) revert ERC725X_ExecuteParametersLengthMismatch();

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -72,12 +72,12 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         /// @dev do not allow to send value by default when setting data in ERC725Y
         if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
 
-        if (dataKeys.length == 0 || dataValues.length == 0) {
-            revert ERC725Y_DataKeysValuesEmptyArray();
-        }
-
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
+        }
+
+        if (dataKeys.length == 0) {
+            revert ERC725Y_DataKeysValuesEmptyArray();
         }
 
         for (uint256 i = 0; i < dataKeys.length; i = _uncheckedIncrementERC725Y(i)) {

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -72,6 +72,10 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
         /// @dev do not allow to send value by default when setting data in ERC725Y
         if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
 
+        if (dataKeys.length == 0 || dataValues.length == 0) {
+            revert ERC725Y_DataKeysValuesEmptyArray();
+        }
+
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -50,6 +50,12 @@ error ERC725X_NoContractBytecodeProvided();
 error ERC725X_ExecuteParametersLengthMismatch();
 
 /**
+ * @dev reverts when one of the array parameter provided to
+ * `execute(uint256[],address[],uint256[],bytes[]) is an empty array
+ */
+error ERC725X_ExecuteParametersEmptyArray();
+
+/**
  * @dev reverts when there is not the same number of elements in the lists of data keys and data values
  * when calling setData(bytes32[],bytes[]).
  * @param dataKeysLength the number of data keys in the bytes32[] dataKeys

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -64,6 +64,12 @@ error ERC725X_ExecuteParametersEmptyArray();
 error ERC725Y_DataKeysValuesLengthMismatch(uint256 dataKeysLength, uint256 dataValuesLength);
 
 /**
+ * @dev reverts when one of the array parameter provided to
+ * `setData(bytes32[],bytes[])` is an empty array
+ */
+error ERC725Y_DataKeysValuesEmptyArray();
+
+/**
  * @dev reverts when sending value to the `setData(..)` functions
  */
 error ERC725Y_MsgValueDisallowed();

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -1797,7 +1797,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
     describe('When testing the execute array function', () => {
       describe('When testing execution ownership', () => {
-        it('should revert if all the array parameters are empty arrays []', async () => {
+        it('should revert if all the array parameters are empty arrays [] [] [] []', async () => {
           const txParams = {
             operations: [],
             targets: [],

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -1797,6 +1797,46 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
     describe('When testing the execute array function', () => {
       describe('When testing execution ownership', () => {
+        it('should revert if all the array parameters are empty arrays []', async () => {
+          const txParams = {
+            operations: [],
+            targets: [],
+            values: [],
+            datas: [],
+          };
+
+          await expect(
+            context.erc725X
+              .connect(context.accounts.owner)
+              ['execute(uint256[],address[],uint256[],bytes[])'](
+                txParams.operations,
+                txParams.targets,
+                txParams.values,
+                txParams.datas,
+              ),
+          ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
+        });
+
+        it('should revert if at least one of the array parameter is an empty array []', async () => {
+          const txParams = {
+            operations: [OPERATION_TYPE.CALL, OPERATION_TYPE.CALL],
+            targets: [context.accounts.anyone.address, context.accounts.anyone.address],
+            values: [],
+            datas: ['0xcafecafe', '0xf00df00d'],
+          };
+
+          await expect(
+            context.erc725X
+              .connect(context.accounts.owner)
+              ['execute(uint256[],address[],uint256[],bytes[])'](
+                txParams.operations,
+                txParams.targets,
+                txParams.values,
+                txParams.datas,
+              ),
+          ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
+        });
+
         describe('When owner is executing', () => {
           it('should pass and emit Executed event', async () => {
             const txParams = {
@@ -1840,6 +1880,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             );
           });
         });
+
         describe('When non-owner is executing', () => {
           it('should revert', async () => {
             const txParams = {

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -1796,6 +1796,46 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
     });
 
     describe('When testing the execute array function', () => {
+      it('should revert if all the array parameters are empty arrays [] [] [] []', async () => {
+        const txParams = {
+          operations: [],
+          targets: [],
+          values: [],
+          datas: [],
+        };
+
+        await expect(
+          context.erc725X
+            .connect(context.accounts.owner)
+            ['execute(uint256[],address[],uint256[],bytes[])'](
+              txParams.operations,
+              txParams.targets,
+              txParams.values,
+              txParams.datas,
+            ),
+        ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
+      });
+
+      it('should revert if at least one of the array parameter is an empty array []', async () => {
+        const txParams = {
+          operations: [OPERATION_TYPE.CALL, OPERATION_TYPE.CALL],
+          targets: [context.accounts.anyone.address, context.accounts.anyone.address],
+          values: [],
+          datas: ['0xcafecafe', '0xf00df00d'],
+        };
+
+        await expect(
+          context.erc725X
+            .connect(context.accounts.owner)
+            ['execute(uint256[],address[],uint256[],bytes[])'](
+              txParams.operations,
+              txParams.targets,
+              txParams.values,
+              txParams.datas,
+            ),
+        ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
+      });
+
       describe('When testing execution ownership', () => {
         it('should revert if all the array parameters are empty arrays [] [] [] []', async () => {
           const txParams = {

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -1796,7 +1796,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
     });
 
     describe('When testing the execute array function', () => {
-      it('should revert if all the array parameters are empty arrays [] [] [] []', async () => {
+      it('should revert with error `ERC725X_ExecuteParametersEmptyArray` if all the array parameters are empty arrays [] [] [] []', async () => {
         const txParams = {
           operations: [],
           targets: [],
@@ -1816,7 +1816,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
         ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
       });
 
-      it('should revert if at least one of the array parameter is an empty array []', async () => {
+      it('should revert with error `ERC725X_ExecuteParametersLengthMismatch` if at least one of the array parameter is an empty array []', async () => {
         const txParams = {
           operations: [OPERATION_TYPE.CALL, OPERATION_TYPE.CALL],
           targets: [context.accounts.anyone.address, context.accounts.anyone.address],
@@ -1833,7 +1833,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               txParams.values,
               txParams.datas,
             ),
-        ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
+        ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersLengthMismatch');
       });
 
       describe('When testing execution ownership', () => {
@@ -1857,7 +1857,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
           ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
         });
 
-        it('should revert if at least one of the array parameter is an empty array []', async () => {
+        it('should revert with error `ERC725X_ExecuteParametersLengthMismatch` if at least one of the array parameter is an empty array []', async () => {
           const txParams = {
             operations: [OPERATION_TYPE.CALL, OPERATION_TYPE.CALL],
             targets: [context.accounts.anyone.address, context.accounts.anyone.address],
@@ -1874,7 +1874,10 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
                 txParams.values,
                 txParams.datas,
               ),
-          ).to.be.revertedWithCustomError(context.erc725X, 'ERC725X_ExecuteParametersEmptyArray');
+          ).to.be.revertedWithCustomError(
+            context.erc725X,
+            'ERC725X_ExecuteParametersLengthMismatch',
+          );
         });
 
         describe('When owner is executing', () => {

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -338,7 +338,33 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         });
       });
     });
+
     describe('When using setData(bytes32[],bytes[])', () => {
+      it('should revert if all parameters are empty arrays [] []', async () => {
+        const dataKeys = [];
+        const dataValues = [];
+
+        await expect(
+          context.erc725Y
+            .connect(context.accounts.owner)
+            ['setData(bytes32[],bytes[])'](dataKeys, dataValues),
+        ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesEmptyArray');
+      });
+
+      it('should revert if at least one of the parameters is an empty array []', async () => {
+        const dataKeys = [
+          ethers.utils.solidityKeccak256(['string'], ['FirstDataKey']),
+          ethers.utils.solidityKeccak256(['string'], ['SecondDataKey']),
+        ];
+        const dataValues = [];
+
+        await expect(
+          context.erc725Y
+            .connect(context.accounts.owner)
+            ['setData(bytes32[],bytes[])'](dataKeys, dataValues),
+        ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesEmptyArray');
+      });
+
       describe('When owner is setting data', () => {
         it('should pass and emit DataChanged event', async () => {
           const txParams = {

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -362,7 +362,9 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           context.erc725Y
             .connect(context.accounts.owner)
             ['setData(bytes32[],bytes[])'](dataKeys, dataValues),
-        ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesEmptyArray');
+        )
+          .to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesLengthMismatch')
+          .withArgs(dataKeys.length, dataValues.length);
       });
 
       describe('When owner is setting data', () => {


### PR DESCRIPTION

# What does this PR introduce?

## 🐛 Bug

When the batch functions below are called with empty array parameters:
- `ERC725X.execute(uint256[],address[],uint256[],bytes[])`
- `ERC725Y.setData(bytes32[],bytes[])`

Nothing happen and the contract call return successfully and silently. Reason being the internal function never enter inside the `for` loops.

Add extra checks to test for empty array parameters in these batch functions.

## 🧪 Tests

Add tests when:
- all the array parameters are empty arrays.
- at least one of the array parameters is an empty array.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
