### PR TITLE
build: upgrade dependencies to fix dependabot security warnings

### DIFF
--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -9,8 +9,8 @@
       "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.7.3",
-        "@openzeppelin/contracts-upgradeable": "^4.7.3",
+        "@openzeppelin/contracts": "^4.8.3",
+        "@openzeppelin/contracts-upgradeable": "^4.8.3",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {
@@ -2012,14 +2012,14 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.3.tgz",
-      "integrity": "sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.3.tgz",
+      "integrity": "sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
-      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz",
+      "integrity": "sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -15198,14 +15198,14 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.3.tgz",
-      "integrity": "sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.3.tgz",
+      "integrity": "sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
-      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz",
+      "integrity": "sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg=="
     },
     "@scure/base": {
       "version": "1.1.1",

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -19,7 +19,7 @@
         "chai": "^4.2.0",
         "coveralls": "^3.1.1",
         "eth-create2-calculator": "^1.1.5",
-        "hardhat": "^2.10.1",
+        "hardhat": "^2.13.1",
         "hardhat-packager": "^1.4.2",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.4.1",
@@ -389,6 +389,32 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@chainsafe/as-sha256": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "dev": true
+    },
+    "node_modules/@chainsafe/persistent-merkle-tree": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
+      "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "node_modules/@chainsafe/ssz": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.4.tgz",
+      "integrity": "sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.4.2",
+        "case": "^1.6.3"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -420,9 +446,9 @@
       }
     },
     "node_modules/@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "dev": true,
       "funding": [
         {
@@ -435,21 +461,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "dev": true,
       "funding": [
         {
@@ -462,19 +488,19 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "dev": true,
       "funding": [
         {
@@ -487,17 +513,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "dev": true,
       "funding": [
         {
@@ -510,17 +536,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "dev": true,
       "funding": [
         {
@@ -533,13 +559,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "dev": true,
       "funding": [
         {
@@ -552,14 +578,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "dev": true,
       "funding": [
         {
@@ -572,15 +598,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "bn.js": "^5.2.1"
       }
     },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "dev": true,
       "funding": [
         {
@@ -593,13 +619,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "dev": true,
       "funding": [
         {
@@ -612,13 +638,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "dev": true,
       "funding": [
         {
@@ -631,22 +657,22 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "dev": true,
       "funding": [
         {
@@ -659,20 +685,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "dev": true,
       "funding": [
         {
@@ -685,24 +712,24 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "dev": true,
       "funding": [
         {
@@ -715,25 +742,25 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "dev": true,
       "funding": [
         {
@@ -746,14 +773,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "dev": true,
       "funding": [
         {
@@ -767,9 +794,9 @@
       ]
     },
     "node_modules/@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "dev": true,
       "funding": [
         {
@@ -782,13 +809,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "dev": true,
       "funding": [
         {
@@ -801,14 +828,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "dev": true,
       "funding": [
         {
@@ -821,13 +848,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "dev": true,
       "funding": [
         {
@@ -840,32 +867,32 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
     },
     "node_modules/@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "dev": true,
       "funding": [
         {
@@ -878,14 +905,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "dev": true,
       "funding": [
         {
@@ -898,14 +925,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "dev": true,
       "funding": [
         {
@@ -918,15 +945,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "dev": true,
       "funding": [
         {
@@ -939,18 +966,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "dev": true,
       "funding": [
         {
@@ -963,18 +990,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "dev": true,
       "funding": [
         {
@@ -987,15 +1014,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "dev": true,
       "funding": [
         {
@@ -1008,21 +1035,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "dev": true,
       "funding": [
         {
@@ -1035,15 +1062,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "dev": true,
       "funding": [
         {
@@ -1056,27 +1083,27 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "dev": true,
       "funding": [
         {
@@ -1089,17 +1116,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "dev": true,
       "funding": [
         {
@@ -1112,11 +1139,11 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@hutson/parse-repository-url": {
@@ -1299,17 +1326,18 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-block": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
-      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.0.tgz",
+      "integrity": "sha512-DfhVbqM5DjriguuSv6r3TgOpyXC76oX8D/VEODsSwJQ1bZGqu4xLLfYPPTacpCAYOnewzJsZli+Ao9TBTAo2uw==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3"
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
+        "ethereum-cryptography": "0.1.3",
+        "ethers": "^5.7.1"
       },
       "engines": {
         "node": ">=14"
@@ -1339,17 +1367,18 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-blockchain": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
-      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.0.tgz",
+      "integrity": "sha512-cVRCrXZminZr0Mbx2hm0/109GZLn1v5bf0/k+SIbGn50yZm6YCdQt9CgGT0Gk56N2vy8NhXD4apo167m4LWk6Q==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
@@ -1385,24 +1414,24 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
-      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.0.tgz",
+      "integrity": "sha512-UPpm5FAGAf2B6hQ8aVgO44Rdo0k73oMMCViqNJcKMlk1s9l3rxwuPTp1l20NiGvNO2Pzqk3chFL+BzmLL2g4wQ==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "crc-32": "^1.2.0"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
-      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.0.tgz",
+      "integrity": "sha512-6zNv5Y3vNIsxjrsbKjMInVpo8cmR0c7yjZbBpy7NYuIMtm0JKhQoXsiFN56t/1sfn9V3v0wgrkAixo5v6bahpA==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "0.1.3"
@@ -1435,15 +1464,15 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
-      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.0.tgz",
+      "integrity": "sha512-D+tr3M9sictopr3E20OVgme7YF/d0fU566WKh+ofXwmxapz/Dd8RSLSaVeKgfCI2BkzVA+XqXY08NNCV8w8fWA==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@ethersproject/providers": "^5.7.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -1477,9 +1506,9 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-rlp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
-      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.0.tgz",
+      "integrity": "sha512-U1A0y330PtGb8Wft4yPVv0myWYJTesi89ItGoB0ICdqz7793KmUhpfQb2vJUXBi98wSdnxkIABO/GmsQvGKVDw==",
       "dev": true,
       "bin": {
         "rlp": "bin/rlp"
@@ -1489,18 +1518,17 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-statemanager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
-      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.0.tgz",
+      "integrity": "sha512-tgXtsx8yIDlxWMN+ThqPtGK0ITAuITrDy+GYIgGrnT6ZtelvXWM7SUYR0Mcv578lmGCoIwyHFtSBqOkOBYHLjw==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1"
+        "ethers": "^5.7.1",
+        "js-sdsl": "^4.1.4"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethereum-cryptography": {
@@ -1527,13 +1555,14 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-trie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
-      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.0.tgz",
+      "integrity": "sha512-YqPWiNxrZvL+Ef7KHqgru1IlaIGXhu78wd2fxNFOvi/NAQBF845dVfTKKXs1L9x0QBRRQRephgxHCKMuISGppw==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
+        "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "0.1.3",
         "readable-stream": "^3.6.0"
       },
@@ -1565,14 +1594,16 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-tx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
-      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.0.tgz",
+      "integrity": "sha512-LTyxI+zBJ+HuEBblUGbxvfKl1hg1uJlz2XhnszNagiBWQSgLb1vQCa1QaXV5Q8cUDYkr/Xe4NXWiUGEvH4e6lA==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethersproject/providers": "^5.7.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
@@ -1603,16 +1634,36 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
-      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.0.tgz",
+      "integrity": "sha512-9EG98CsEC9BnI7AY27F4QXZ8Vf0re8R9XoxQ0//KWF+B7quu6GQvgTq1RlNUjGh/XNCCJNf8E3LOY9ULR85wFQ==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "@chainsafe/ssz": "^0.10.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/persistent-merkle-tree": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
+      "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/ssz": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
+      "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.5.0"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util/node_modules/ethereum-cryptography": {
@@ -1639,25 +1690,22 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-vm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
-      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.0.tgz",
+      "integrity": "sha512-eHkEoe/4r4+g+fZyIIlQjBHEjCPFs8CHiIEEMvMfvFrV4hyHnuTg4LH7l92ok7TGZqpWxgMG2JOEUFkNsXrKuQ==",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-evm": "2.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
         "rustbn.js": "~0.2.0"
       },
@@ -2238,12 +2286,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@types/async-eventemitter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
-      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg==",
-      "dev": true
-    },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -2356,6 +2398,22 @@
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
@@ -2877,24 +2935,12 @@
       "dev": true
     },
     "node_modules/bigint-crypto-utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.8.tgz",
-      "integrity": "sha512-+VMV9Laq8pXLBKKKK49nOoq9bfR3j7NNQAtbA617a4nw9bVLo8rsqkKMBgM2AJWlNX9fEIyYaYX+d0laqYV4tw==",
-      "dev": true,
-      "dependencies": {
-        "bigint-mod-arith": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      }
-    },
-    "node_modules/bigint-mod-arith": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
-      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.2.2.tgz",
+      "integrity": "sha512-U1RbE3aX9ayCUVcIPHuPDPKcK3SFOXf93J1UK/iHlJuQB7bhagPIX06/CLpLEsDThJ7KA4Dhrnzynl+d2weTiw==",
       "dev": true,
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -3198,6 +3244,15 @@
         }
       ]
     },
+    "node_modules/case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3358,16 +3413,16 @@
       }
     },
     "node_modules/classic-level": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
+      "integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "abstract-level": "^1.0.2",
         "catering": "^2.1.0",
         "module-error": "^1.0.1",
-        "napi-macros": "~2.0.0",
+        "napi-macros": "^2.2.2",
         "node-gyp-build": "^4.3.0"
       },
       "engines": {
@@ -6090,9 +6145,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "dev": true,
       "funding": [
         {
@@ -6105,36 +6160,36 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/ethjs-unit": {
@@ -7048,23 +7103,23 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.5.tgz",
-      "integrity": "sha512-f/t7+hLlhsnQZ6LDXyV+8rHGRZFZY1sgFvgrwr9fBjMdGp1Bu6hHq1KXS4/VFZfZcVdL1DAWWEkryinZhqce+A==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.13.1.tgz",
+      "integrity": "sha512-ZZL7LQxHmbw4JQJsiEv2qE35nbR+isr2sIdtgZVPp0+zWqRkpr1OT7gmvhCNYfjpEPyfjZIxWriQWlphJhVPLQ==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-evm": "2.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
+        "@nomicfoundation/ethereumjs-vm": "7.0.0",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
@@ -7100,15 +7155,15 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
       "bin": {
-        "hardhat": "internal/cli/cli.js"
+        "hardhat": "internal/cli/bootstrap.js"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "ts-node": "*",
@@ -8549,6 +8604,16 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
+    "node_modules/js-sdsl": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -9647,9 +9712,9 @@
       }
     },
     "node_modules/napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -13987,6 +14052,32 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@chainsafe/as-sha256": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "dev": true
+    },
+    "@chainsafe/persistent-merkle-tree": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
+      "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "dev": true,
+      "requires": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "@chainsafe/ssz": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.4.tgz",
+      "integrity": "sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==",
+      "dev": true,
+      "requires": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.4.2",
+        "case": "^1.6.3"
+      }
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -14015,403 +14106,404 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "dev": true,
       "requires": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "bn.js": "^5.2.1"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "dev": true
     },
     "@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
     },
     "@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "dev": true,
       "requires": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@hutson/parse-repository-url": {
@@ -14560,17 +14652,18 @@
       }
     },
     "@nomicfoundation/ethereumjs-block": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
-      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.0.tgz",
+      "integrity": "sha512-DfhVbqM5DjriguuSv6r3TgOpyXC76oX8D/VEODsSwJQ1bZGqu4xLLfYPPTacpCAYOnewzJsZli+Ao9TBTAo2uw==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3"
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
+        "ethereum-cryptography": "0.1.3",
+        "ethers": "^5.7.1"
       },
       "dependencies": {
         "ethereum-cryptography": {
@@ -14599,17 +14692,18 @@
       }
     },
     "@nomicfoundation/ethereumjs-blockchain": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
-      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.0.tgz",
+      "integrity": "sha512-cVRCrXZminZr0Mbx2hm0/109GZLn1v5bf0/k+SIbGn50yZm6YCdQt9CgGT0Gk56N2vy8NhXD4apo167m4LWk6Q==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
@@ -14644,24 +14738,24 @@
       }
     },
     "@nomicfoundation/ethereumjs-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
-      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.0.tgz",
+      "integrity": "sha512-UPpm5FAGAf2B6hQ8aVgO44Rdo0k73oMMCViqNJcKMlk1s9l3rxwuPTp1l20NiGvNO2Pzqk3chFL+BzmLL2g4wQ==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "crc-32": "^1.2.0"
       }
     },
     "@nomicfoundation/ethereumjs-ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
-      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.0.tgz",
+      "integrity": "sha512-6zNv5Y3vNIsxjrsbKjMInVpo8cmR0c7yjZbBpy7NYuIMtm0JKhQoXsiFN56t/1sfn9V3v0wgrkAixo5v6bahpA==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "0.1.3"
@@ -14693,15 +14787,15 @@
       }
     },
     "@nomicfoundation/ethereumjs-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
-      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.0.tgz",
+      "integrity": "sha512-D+tr3M9sictopr3E20OVgme7YF/d0fU566WKh+ofXwmxapz/Dd8RSLSaVeKgfCI2BkzVA+XqXY08NNCV8w8fWA==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@ethersproject/providers": "^5.7.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -14734,24 +14828,23 @@
       }
     },
     "@nomicfoundation/ethereumjs-rlp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
-      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.0.tgz",
+      "integrity": "sha512-U1A0y330PtGb8Wft4yPVv0myWYJTesi89ItGoB0ICdqz7793KmUhpfQb2vJUXBi98wSdnxkIABO/GmsQvGKVDw==",
       "dev": true
     },
     "@nomicfoundation/ethereumjs-statemanager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
-      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.0.tgz",
+      "integrity": "sha512-tgXtsx8yIDlxWMN+ThqPtGK0ITAuITrDy+GYIgGrnT6ZtelvXWM7SUYR0Mcv578lmGCoIwyHFtSBqOkOBYHLjw==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1"
+        "ethers": "^5.7.1",
+        "js-sdsl": "^4.1.4"
       },
       "dependencies": {
         "ethereum-cryptography": {
@@ -14780,13 +14873,14 @@
       }
     },
     "@nomicfoundation/ethereumjs-trie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
-      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.0.tgz",
+      "integrity": "sha512-YqPWiNxrZvL+Ef7KHqgru1IlaIGXhu78wd2fxNFOvi/NAQBF845dVfTKKXs1L9x0QBRRQRephgxHCKMuISGppw==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
+        "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "0.1.3",
         "readable-stream": "^3.6.0"
       },
@@ -14817,14 +14911,16 @@
       }
     },
     "@nomicfoundation/ethereumjs-tx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
-      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.0.tgz",
+      "integrity": "sha512-LTyxI+zBJ+HuEBblUGbxvfKl1hg1uJlz2XhnszNagiBWQSgLb1vQCa1QaXV5Q8cUDYkr/Xe4NXWiUGEvH4e6lA==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethersproject/providers": "^5.7.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "ethereum-cryptography": "0.1.3"
       },
       "dependencies": {
@@ -14854,15 +14950,35 @@
       }
     },
     "@nomicfoundation/ethereumjs-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
-      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.0.tgz",
+      "integrity": "sha512-9EG98CsEC9BnI7AY27F4QXZ8Vf0re8R9XoxQ0//KWF+B7quu6GQvgTq1RlNUjGh/XNCCJNf8E3LOY9ULR85wFQ==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "@chainsafe/ssz": "^0.10.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
         "ethereum-cryptography": "0.1.3"
       },
       "dependencies": {
+        "@chainsafe/persistent-merkle-tree": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
+          "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/as-sha256": "^0.3.1"
+          }
+        },
+        "@chainsafe/ssz": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
+          "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/as-sha256": "^0.3.1",
+            "@chainsafe/persistent-merkle-tree": "^0.5.0"
+          }
+        },
         "ethereum-cryptography": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
@@ -14889,25 +15005,22 @@
       }
     },
     "@nomicfoundation/ethereumjs-vm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
-      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.0.tgz",
+      "integrity": "sha512-eHkEoe/4r4+g+fZyIIlQjBHEjCPFs8CHiIEEMvMfvFrV4hyHnuTg4LH7l92ok7TGZqpWxgMG2JOEUFkNsXrKuQ==",
       "dev": true,
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-evm": "2.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
         "rustbn.js": "~0.2.0"
       },
@@ -15298,12 +15411,6 @@
         }
       }
     },
-    "@types/async-eventemitter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
-      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg==",
-      "dev": true
-    },
     "@types/bn.js": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -15416,6 +15523,24 @@
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true,
       "peer": true
+    },
+    "@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -15828,18 +15953,9 @@
       "dev": true
     },
     "bigint-crypto-utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.8.tgz",
-      "integrity": "sha512-+VMV9Laq8pXLBKKKK49nOoq9bfR3j7NNQAtbA617a4nw9bVLo8rsqkKMBgM2AJWlNX9fEIyYaYX+d0laqYV4tw==",
-      "dev": true,
-      "requires": {
-        "bigint-mod-arith": "^3.1.0"
-      }
-    },
-    "bigint-mod-arith": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
-      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.2.2.tgz",
+      "integrity": "sha512-U1RbE3aX9ayCUVcIPHuPDPKcK3SFOXf93J1UK/iHlJuQB7bhagPIX06/CLpLEsDThJ7KA4Dhrnzynl+d2weTiw==",
       "dev": true
     },
     "bignumber.js": {
@@ -16059,6 +16175,12 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
       "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw=="
     },
+    "case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -16186,15 +16308,15 @@
       }
     },
     "classic-level": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
+      "integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
       "dev": true,
       "requires": {
         "abstract-level": "^1.0.2",
         "catering": "^2.1.0",
         "module-error": "^1.0.1",
-        "napi-macros": "~2.0.0",
+        "napi-macros": "^2.2.2",
         "node-gyp-build": "^4.3.0"
       }
     },
@@ -18570,41 +18692,41 @@
       }
     },
     "ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "ethjs-unit": {
@@ -19313,23 +19435,23 @@
       "dev": true
     },
     "hardhat": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.5.tgz",
-      "integrity": "sha512-f/t7+hLlhsnQZ6LDXyV+8rHGRZFZY1sgFvgrwr9fBjMdGp1Bu6hHq1KXS4/VFZfZcVdL1DAWWEkryinZhqce+A==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.13.1.tgz",
+      "integrity": "sha512-ZZL7LQxHmbw4JQJsiEv2qE35nbR+isr2sIdtgZVPp0+zWqRkpr1OT7gmvhCNYfjpEPyfjZIxWriQWlphJhVPLQ==",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.0",
+        "@nomicfoundation/ethereumjs-evm": "2.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.0",
+        "@nomicfoundation/ethereumjs-trie": "6.0.0",
+        "@nomicfoundation/ethereumjs-tx": "5.0.0",
+        "@nomicfoundation/ethereumjs-util": "9.0.0",
+        "@nomicfoundation/ethereumjs-vm": "7.0.0",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
@@ -19365,7 +19487,7 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -20420,6 +20542,12 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
+    "js-sdsl": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+      "dev": true
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -21278,9 +21406,9 @@
       "dev": true
     },
     "napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
       "dev": true
     },
     "natural-compare": {

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -14,7 +14,7 @@
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {
-        "@nomicfoundation/hardhat-toolbox": "^2.0.0",
+        "@nomicfoundation/hardhat-toolbox": "^2.0.2",
         "@types/chai": "^4.3.1",
         "chai": "^4.2.0",
         "coveralls": "^3.1.1",
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-toolbox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.0.tgz",
-      "integrity": "sha512-BoOPbzLQ1GArnBZd4Jz4IU8FY3RY4nUwpXlfymXwxlXNimngkPRJj7ivVNurD7igohEjf90v/Axn2M5WwAdCJQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.2.tgz",
+      "integrity": "sha512-vnN1AzxbvpSx9pfdRHbUzTRIXpMLPXnUlkW855VaDk6N1pwRaQ2gNzEmFAABk4lWf11E00PKwFd/q27HuwYrYg==",
       "dev": true,
       "peerDependencies": {
         "@ethersproject/abi": "^5.4.7",
@@ -1785,7 +1785,7 @@
         "@typechain/ethers-v5": "^10.1.0",
         "@typechain/hardhat": "^6.1.2",
         "@types/chai": "^4.2.0",
-        "@types/mocha": "^9.1.0",
+        "@types/mocha": ">=9.1.0",
         "@types/node": ">=12.0.0",
         "chai": "^4.2.0",
         "ethers": "^5.4.7",
@@ -15076,9 +15076,9 @@
       }
     },
     "@nomicfoundation/hardhat-toolbox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.0.tgz",
-      "integrity": "sha512-BoOPbzLQ1GArnBZd4Jz4IU8FY3RY4nUwpXlfymXwxlXNimngkPRJj7ivVNurD7igohEjf90v/Axn2M5WwAdCJQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.2.tgz",
+      "integrity": "sha512-vnN1AzxbvpSx9pfdRHbUzTRIXpMLPXnUlkW855VaDk6N1pwRaQ2gNzEmFAABk4lWf11E00PKwFd/q27HuwYrYg==",
       "dev": true,
       "requires": {}
     },

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -42,7 +42,7 @@
     "chai": "^4.2.0",
     "coveralls": "^3.1.1",
     "eth-create2-calculator": "^1.1.5",
-    "hardhat": "^2.10.1",
+    "hardhat": "^2.13.1",
     "hardhat-packager": "^1.4.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -37,7 +37,7 @@
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {
-    "@nomicfoundation/hardhat-toolbox": "^2.0.0",
+    "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "@types/chai": "^4.3.1",
     "chai": "^4.2.0",
     "coveralls": "^3.1.1",

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -32,8 +32,8 @@
   "author": "Fabian Vogelsteller <fabian@lukso.network>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@openzeppelin/contracts": "^4.7.3",
-    "@openzeppelin/contracts-upgradeable": "^4.7.3",
+    "@openzeppelin/contracts": "^4.8.3",
+    "@openzeppelin/contracts-upgradeable": "^4.8.3",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to ERC725! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

Upgrade dependencies to fix Dependabot Security warning for: _"flat vulnerable to Prototype Pollution"_

## 📦 Build

> NB: hardhat 2.13.1 adds supports for Shangaï upgrade.
> see details: https://github.com/NomicFoundation/hardhat/releases/tag/hardhat%402.13.1

Upgrade the following dependencies to fix dependabot security warnings (screenshot below).

- `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradable`: `4.7.3` --> upgraded to `4.8.3`
- `hardhat`: `2.10.1` --> upgraded to `2.13.1`. 
- `@nomicfoundation/hardhat-toolbox`: `2.0.0` --> `2.0.2`


![image](https://user-images.githubusercontent.com/31145285/233373123-fa5f545b-530e-454d-83a3-bb4260d1808d.png)

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
