### PR TITLE
refactor!: remove function overloading

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -41,7 +41,7 @@ And the event:
 
 ### ERC725X
 
-**ERC725X** interface id according to [ERC165]: `0x570ef073`.
+**ERC725X** interface id according to [ERC165]: `0x7545acac`.
 
 Smart contracts implementing the ERC725X standard MUST implement the [ERC165] `supportsInterface(..)` function and MUST support the ERC165 and ERC725X interface ids.
 
@@ -103,13 +103,13 @@ data = <contract-creation-code> + <abi-encoded-constructor-arguments> + <bytes32
 
 > See [EIP-1014: Skinny CREATE2](https://eips.ethereum.org/EIPS/eip-1014) for more information.
 
-#### execute (Array)
+#### executeBatch
 
 ```solidity
-function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory)
+function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory)
 ```
 
-Function Selector: `0x13ced88d`
+Function Selector: `0x31858452`
 
 Executes a batch of calls on any other smart contracts, transfers the blockchain native token, or deploys a new smart contract.
 MUST only be called by the current owner of the contract.
@@ -134,26 +134,6 @@ _Returns:_ `bytes[]` , array list of returned data of the called function, or th
 
 **Triggers Event:** [ContractCreated](#contractcreated), [Executed](#executed) on each call iteration
 
-**Note:** The `execute()` functions use function overloading, therefore it is better to reference them by the given function signature as follows:
-
-```js
-// web3.js example
-
-// execute
-myContract.methods['execute(uint256,address,uint256,bytes)'](OPERATION_CALL, target.address, 2WEI, "0x").send();
-
-// execute Array
-myContract.methods['execute(uint256[],address[],uint256[],bytes[])']([OPERATION_CALL, OPERATION_CREATE], [target.address, ZERO_ADDRESS], [2WEI, 0WEI], ["0x", CONTRACT_BYTECODE]).send()
-
-// OR
-
-// execute
-myContract.methods['0x44c028fe'](OPERATION_CALL, target.address, 2WEI, "0x").send();
-
-// execute Array
-myContract.methods['0x13ced88d']([OPERATION_CALL, OPERATION_CREATE], [target.address, ZERO_ADDRESS], [2WEI, 0WEI], ["0x", CONTRACT_BYTECODE]).send()
-```
-
 ### Events
 
 #### Executed
@@ -176,7 +156,7 @@ MUST be triggered when `execute` creates a new contract using the `operationType
 
 ### ERC725Y
 
-**ERC725Y** interface id according to [ERC165]: `0x714df77c`.
+**ERC725Y** interface id according to [ERC165]: `0x629aa694`.
 
 Smart contracts implementing the ERC725Y standard MUST implement the [ERC165] `supportsInterface(..)` function and MUST support the ERC165 and ERC725Y interface ids.
 
@@ -200,13 +180,13 @@ _Parameters:_
 
 _Returns:_ `bytes` , The data for the requested data key.
 
-#### getData (Array)
+#### getDataBatch
 
 ```solidity
 function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory)
 ```
 
-Function Selector: `0x4e3e6e9c`
+Function Selector: `0xdedff9c6`
 
 Gets array of data at multiple given data keys.
 
@@ -237,13 +217,13 @@ _Requirements:_
 
 **Triggers Event:** [DataChanged](#datachanged)
 
-#### setData (Array)
+#### setDataBatch
 
 ```solidity
 function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable
 ```
 
-Function Selector: `0x14a6e293`
+Function Selector: `0x97902421`
 
 Sets array of data at multiple data keys. MUST only be called by the current owner of the contract.
 
@@ -258,26 +238,6 @@ _Requirements:_
 - MUST only be called by the current owner of the contract.
 
 **Triggers Event:** [DataChanged](#datachanged)
-
-**Note:** `setData()` and `getData()` uses function overloading, therefore it is better to reference them by the given function signature as follows:
-
-```js
-// web3.js example
-
-// setData
-myContract.methods['setData(bytes32,bytes)'](dataKey, dataValue).send()
-
-// setData Array
-myContract.methods['setData(bytes32[],bytes[])']([dataKeys, ...], [dataValues, ...]).send()
-
-// OR
-
-// setData
-myContract.methods['0x7f23690c'](dataKey, dataValue).send()
-
-// setData Array
-myContract.methods['0x14a6e293']([dataKeys, ...], [dataValues, ...]).send()
-```
 
 ### Events
 
@@ -304,7 +264,7 @@ The data stored in an ERC725Y smart contract is not only readable/writable by of
 
 ## Backwards Compatibility
 
-All contracts since ERC725v2 from 2018/19 should be compatible to the current version of the standard. Mainly interface ID and Event parameters have changed, while `getData(bytes32[])` and `setData(bytes32[], bytes[])` was added as an efficient way to set/get multiple keys at once. The same applies for execution, as `execute(..[])` was added as an efficient way to batch calls.
+All contracts since ERC725v2 from 2018/19 should be compatible to the current version of the standard. Mainly interface ID and Event parameters have changed, while `getDataBatch(bytes32[])` and `setDataBatch(bytes32[], bytes[])` was added as an efficient way to set/get multiple keys at once. The same applies for execution, as `executeBatch(..[])` was added as an efficient way to batch calls.
 
 ## Reference Implementation
 
@@ -322,25 +282,24 @@ When using the operation type `4` for `delegatecall`, it is important to conside
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity >=0.5.0 <0.7.0;
 
-// ERC165 identifier: `0x570ef073`
 interface IERC725X  /* is ERC165, ERC173 */ {
     event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
     event Executed(uint256 indexed operationType, address indexed target, uint256 indexed  value, bytes4 data);
 
     function execute(uint256 operationType, address target, uint256 value, bytes memory data) external payable returns(bytes memory);
 
-    function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes memory datas) external payable returns(bytes[] memory);
+    function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes memory datas) external payable returns(bytes[] memory);
 }
 
-// ERC165 identifier: `0x714df77c`
+
 interface IERC725Y /* is ERC165, ERC173 */ {
     event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
     function getData(bytes32 dataKey) external view returns(bytes memory);
-    function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory);
+    function getDataBatch(bytes32[] memory dataKeys) external view returns(bytes[] memory);
 
     function setData(bytes32 dataKey, bytes memory dataValue) external;
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
 }
 
 interface IERC725 /* is IERC725X, IERC725Y */ {

--- a/implementations/constants.js
+++ b/implementations/constants.js
@@ -1,7 +1,7 @@
 const INTERFACE_ID = {
   ERC165: '0x01ffc9a7',
-  ERC725X: '0x570ef073',
-  ERC725Y: '0x714df77c',
+  ERC725X: '0x7545acac',
+  ERC725Y: '0x629aa694',
 };
 
 const OPERATION_TYPE = {
@@ -14,9 +14,9 @@ const OPERATION_TYPE = {
 
 const FUNCTIONS_SELECTOR = {
   EXECUTE: '0x44c028fe',
-  EXECUTE_ARRAY: '0x13ced88d',
+  EXECUTE_BATCH: '0x31858452',
   SETDATA: '0x7f23690c',
-  SETDATA_ARRAY: '0x14a6e293',
+  SETDATA_BATCH: '0x97902421',
 };
 
 const Errors = {

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -49,13 +49,13 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     /**
      * @inheritdoc IERC725X
      */
-    function execute(
+    function executeBatch(
         uint256[] memory operationsType,
         address[] memory targets,
         uint256[] memory values,
         bytes[] memory datas
     ) public payable virtual override onlyOwner returns (bytes[] memory) {
-        return _execute(operationsType, targets, values, datas);
+        return _executeBatch(operationsType, targets, values, datas);
     }
 
     /**
@@ -124,7 +124,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
      * @dev same as `_execute` but for batch execution
      * see `IERC725X,execute(uint256[],address[],uint256[],bytes[])`
      */
-    function _execute(
+    function _executeBatch(
         uint256[] memory operationsType,
         address[] memory targets,
         uint256[] memory values,

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -39,7 +39,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function getData(
+    function getDataBatch(
         bytes32[] memory dataKeys
     ) public view virtual override returns (bytes[] memory dataValues) {
         dataValues = new bytes[](dataKeys.length);
@@ -65,7 +65,7 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function setData(
+    function setDataBatch(
         bytes32[] memory dataKeys,
         bytes[] memory dataValues
     ) public payable virtual override onlyOwner {

--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.0;
 
 // ERC165 INTERFACE IDs
-bytes4 constant _INTERFACEID_ERC725X = 0x570ef073;
-bytes4 constant _INTERFACEID_ERC725Y = 0x714df77c;
+bytes4 constant _INTERFACEID_ERC725X = 0x7545acac;
+bytes4 constant _INTERFACEID_ERC725Y = 0x629aa694;
 
-// ERC725X overloaded function selectors
+// ERC725X function selectors
 bytes4 constant EXECUTE_SELECTOR = 0x44c028fe;
-bytes4 constant EXECUTE_ARRAY_SELECTOR = 0x13ced88d;
+bytes4 constant EXECUTE_BATCH_SELECTOR = 0x31858452;
 
 // ERC725X OPERATION TYPES
 uint256 constant OPERATION_0_CALL = 0;
@@ -16,6 +16,6 @@ uint256 constant OPERATION_2_CREATE2 = 2;
 uint256 constant OPERATION_3_STATICCALL = 3;
 uint256 constant OPERATION_4_DELEGATECALL = 4;
 
-// ERC725Y overloaded function selectors
+// ERC725Y function selectors
 bytes4 constant SETDATA_SELECTOR = 0x7f23690c;
-bytes4 constant SETDATA_ARRAY_SELECTOR = 0x14a6e293;
+bytes4 constant SETDATA_BATCH_SELECTOR = 0x97902421;

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 /**
  * @dev reverts when trying to send more native tokens `value` than available in current `balance`.
  * @param balance the balance of the ERC725X contract.
- * @param value the amount of native tokens sent via `ERC725X.execute(...)`.
+ * @param value the amount of native tokens sent via `ERC725X.execute/Batch(...)`.
  */
 error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
 
@@ -16,31 +16,31 @@ error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
 
 /**
  * @dev the `value` parameter (= sending native tokens) is not allowed when making a staticcall
- * via `ERC725X.execute(...)` because sending native tokens is a state changing operation.
+ * via `ERC725X.execute/Batch(...)` because sending native tokens is a state changing operation.
  */
 error ERC725X_MsgValueDisallowedInStaticCall();
 
 /**
  * @dev the `value` parameter (= sending native tokens) is not allowed when making a delegatecall
- * via `ERC725X.execute(...)` because msg.value is persisting.
+ * via `ERC725X.execute/Batch(...)` because msg.value is persisting.
  */
 error ERC725X_MsgValueDisallowedInDelegateCall();
 
 /**
- * @dev reverts when passing a `to` address while deploying a contract va `ERC725X.execute(...)`
+ * @dev reverts when passing a `to` address while deploying a contract va `ERC725X.execute/Batch(...)`
  * whether using operation type 1 (CREATE) or 2 (CREATE2).
  */
 error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
 
 /**
- * @dev reverts when contract deployment via `ERC725X.execute(...)` failed.
+ * @dev reverts when contract deployment via `ERC725X.execute/Batch(...)` failed.
  * whether using operation type 1 (CREATE) or 2 (CREATE2).
  */
 error ERC725X_ContractDeploymentFailed();
 
 /**
  * @dev reverts when no contract bytecode was provided as parameter when trying to deploy a contract
- * via `ERC725X.execute(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
+ * via `ERC725X.execute/Batch(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
  */
 error ERC725X_NoContractBytecodeProvided();
 
@@ -51,13 +51,13 @@ error ERC725X_ExecuteParametersLengthMismatch();
 
 /**
  * @dev reverts when one of the array parameter provided to
- * `execute(uint256[],address[],uint256[],bytes[]) is an empty array
+ * `executeBatch(uint256[],address[],uint256[],bytes[]) is an empty array
  */
 error ERC725X_ExecuteParametersEmptyArray();
 
 /**
  * @dev reverts when there is not the same number of elements in the lists of data keys and data values
- * when calling setData(bytes32[],bytes[]).
+ * when calling setDataBatch.
  * @param dataKeysLength the number of data keys in the bytes32[] dataKeys
  * @param dataValuesLength the number of data value in the bytes[] dataValue
  */
@@ -65,7 +65,7 @@ error ERC725Y_DataKeysValuesLengthMismatch(uint256 dataKeysLength, uint256 dataV
 
 /**
  * @dev reverts when one of the array parameter provided to
- * `setData(bytes32[],bytes[])` is an empty array
+ * `setDataBatch` is an empty array
  */
 error ERC725Y_DataKeysValuesEmptyArray();
 

--- a/implementations/contracts/helpers/ConstantsChecker.sol
+++ b/implementations/contracts/helpers/ConstantsChecker.sol
@@ -38,11 +38,11 @@ contract ConstantsChecker {
 
     function getExecuteArraySelector() public pure returns (bytes4) {
         require(
-            EXECUTE_ARRAY_SELECTOR ==
-                bytes4(keccak256("execute(uint256[],address[],uint256[],bytes[])")),
-            "hardcoded EXECUTE_ARRAY_SELECTOR in `constants.sol` does not match `IERC725X.execute.selector`"
+            EXECUTE_BATCH_SELECTOR ==
+                bytes4(keccak256("executeBatch(uint256[],address[],uint256[],bytes[])")),
+            "hardcoded EXECUTE_BATCH_SELECTOR in `constants.sol` does not match `IERC725X.execute.selector`"
         );
-        return bytes4(keccak256("execute(uint256[],address[],uint256[],bytes[])"));
+        return bytes4(keccak256("executeBatch(uint256[],address[],uint256[],bytes[])"));
     }
 
     function getSetDataSelector() public pure returns (bytes4) {
@@ -55,9 +55,9 @@ contract ConstantsChecker {
 
     function getSetDataArraySelector() public pure returns (bytes4) {
         require(
-            SETDATA_ARRAY_SELECTOR == bytes4(keccak256("setData(bytes32[],bytes[])")),
-            "hardcoded SETDATA_ARRAY_SELECTOR in `constants.sol` does not match `IERC725Y.setData.selector`"
+            SETDATA_BATCH_SELECTOR == bytes4(keccak256("setDataBatch(bytes32[],bytes[])")),
+            "hardcoded SETDATA_BATCH_SELECTOR in `constants.sol` does not match `IERC725Y.setData.selector`"
         );
-        return bytes4(keccak256("setData(bytes32[],bytes[])"));
+        return bytes4(keccak256("setDataBatch(bytes32[],bytes[])"));
     }
 }

--- a/implementations/contracts/helpers/ConstantsChecker.sol
+++ b/implementations/contracts/helpers/ConstantsChecker.sol
@@ -30,34 +30,33 @@ contract ConstantsChecker {
 
     function getExecuteSelector() public pure returns (bytes4) {
         require(
-            EXECUTE_SELECTOR == bytes4(keccak256("execute(uint256,address,uint256,bytes)")),
+            EXECUTE_SELECTOR == IERC725X.execute.selector,
             "hardcoded EXECUTE_SELECTOR in `constants.sol` does not match `IERC725X.execute.selector`"
         );
-        return bytes4(keccak256("execute(uint256,address,uint256,bytes)"));
+        return IERC725X.execute.selector;
     }
 
     function getExecuteArraySelector() public pure returns (bytes4) {
         require(
-            EXECUTE_BATCH_SELECTOR ==
-                bytes4(keccak256("executeBatch(uint256[],address[],uint256[],bytes[])")),
+            EXECUTE_BATCH_SELECTOR == IERC725X.executeBatch.selector,
             "hardcoded EXECUTE_BATCH_SELECTOR in `constants.sol` does not match `IERC725X.execute.selector`"
         );
-        return bytes4(keccak256("executeBatch(uint256[],address[],uint256[],bytes[])"));
+        return IERC725X.executeBatch.selector;
     }
 
     function getSetDataSelector() public pure returns (bytes4) {
         require(
-            SETDATA_SELECTOR == bytes4(keccak256("setData(bytes32,bytes)")),
+            SETDATA_SELECTOR == IERC725Y.setData.selector,
             "hardcoded SETDATA_SELECTOR in `constants.sol` does not match `IERC725Y.setData.selector`"
         );
-        return bytes4(keccak256("setData(bytes32,bytes)"));
+        return IERC725Y.setData.selector;
     }
 
     function getSetDataArraySelector() public pure returns (bytes4) {
         require(
-            SETDATA_BATCH_SELECTOR == bytes4(keccak256("setDataBatch(bytes32[],bytes[])")),
+            SETDATA_BATCH_SELECTOR == IERC725Y.setDataBatch.selector,
             "hardcoded SETDATA_BATCH_SELECTOR in `constants.sol` does not match `IERC725Y.setData.selector`"
         );
-        return bytes4(keccak256("setDataBatch(bytes32[],bytes[])"));
+        return IERC725Y.setDataBatch.selector;
     }
 }

--- a/implementations/contracts/helpers/ERC725YReader.sol
+++ b/implementations/contracts/helpers/ERC725YReader.sol
@@ -8,15 +8,14 @@ import {IERC725Y} from "../interfaces/IERC725Y.sol";
  * @dev Contract used for testing
  */
 contract ERC725YReader {
-    function callGetDataArray(address to, bytes32[] calldata _keys)
-        public
-        view
-        returns (bytes[] memory)
-    {
-        return IERC725Y(to).getData(_keys);
+    function callGetDataBatch(
+        address to,
+        bytes32[] calldata _keys
+    ) public view returns (bytes[] memory) {
+        return IERC725Y(to).getDataBatch(_keys);
     }
 
-    function callGetDataSingle(address to, bytes32 _key) public view returns (bytes memory) {
+    function callGetData(address to, bytes32 _key) public view returns (bytes memory) {
         return IERC725Y(to).getData(_key);
     }
 }

--- a/implementations/contracts/helpers/ERC725YWriter.sol
+++ b/implementations/contracts/helpers/ERC725YWriter.sol
@@ -8,19 +8,15 @@ import {IERC725Y} from "../interfaces/IERC725Y.sol";
  * @dev Contract used for testing
  */
 contract ERC725YWriter {
-    function callSetDataArray(
+    function callSetDataBatch(
         address to,
         bytes32[] calldata _keys,
         bytes[] calldata _values
     ) public {
-        IERC725Y(to).setData(_keys, _values);
+        IERC725Y(to).setDataBatch(_keys, _values);
     }
 
-    function callSetDataSingle(
-        address to,
-        bytes32 _key,
-        bytes calldata _value
-    ) public {
+    function callSetData(address to, bytes32 _key, bytes calldata _value) public {
         IERC725Y(to).setData(_key, _value);
     }
 }

--- a/implementations/contracts/helpers/Reader.sol
+++ b/implementations/contracts/helpers/Reader.sol
@@ -11,14 +11,14 @@ contract Reader {
     }
 
     /**
-     * @dev do not put the `view` modifier, so to display the gas usage of `getData(...)`
+     * @dev do not put the `view` modifier, so to display the gas usage of `getDataBatch(...)`
      *  in the gas reporter of the test suite
      */
     function read(bytes32 _key) public view returns (bytes memory) {
         bytes32[] memory keys = new bytes32[](1);
         keys[0] = _key;
 
-        bytes[] memory result = erc725y.getData(keys);
+        bytes[] memory result = erc725y.getDataBatch(keys);
         return result[0];
     }
 }

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -90,7 +90,7 @@ interface IERC725X is IERC165 {
      * Emits an {Executed} event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL)
      * Emits a {ContractCreated} event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
      */
-    function execute(
+    function executeBatch(
         uint256[] memory operationsType,
         address[] memory targets,
         uint256[] memory values,

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -30,7 +30,9 @@ interface IERC725Y is IERC165 {
      * @param dataKeys The array of keys which values to retrieve
      * @return dataValues The array of data stored at multiple keys
      */
-    function getData(bytes32[] memory dataKeys) external view returns (bytes[] memory dataValues);
+    function getDataBatch(
+        bytes32[] memory dataKeys
+    ) external view returns (bytes[] memory dataValues);
 
     /**
      * @notice Sets singular data for a given `dataKey`
@@ -60,5 +62,5 @@ interface IERC725Y is IERC165 {
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable;
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external payable;
 }

--- a/implementations/test/ConstantsChecker.test.ts
+++ b/implementations/test/ConstantsChecker.test.ts
@@ -19,15 +19,11 @@ describe('Constants Checker', () => {
   describe('Calculating ERC165InterfaceIds', () => {
     it('ERC725X', async () => {
       const result = await contract.getERC725XInterfaceID();
-      console.log(result);
-      
       expect(result).to.equal(INTERFACE_ID.ERC725X);
     });
 
     it('ERC725Y', async () => {
       const result = await contract.getERC725YInterfaceID();
-      console.log(result);
-      
       expect(result).to.equal(INTERFACE_ID.ERC725Y);
     });
   });

--- a/implementations/test/ConstantsChecker.test.ts
+++ b/implementations/test/ConstantsChecker.test.ts
@@ -19,11 +19,15 @@ describe('Constants Checker', () => {
   describe('Calculating ERC165InterfaceIds', () => {
     it('ERC725X', async () => {
       const result = await contract.getERC725XInterfaceID();
+      console.log(result);
+      
       expect(result).to.equal(INTERFACE_ID.ERC725X);
     });
 
     it('ERC725Y', async () => {
       const result = await contract.getERC725YInterfaceID();
+      console.log(result);
+      
       expect(result).to.equal(INTERFACE_ID.ERC725Y);
     });
   });
@@ -37,7 +41,7 @@ describe('Constants Checker', () => {
 
       it('execute array selector', async () => {
         const result = await contract.getExecuteArraySelector();
-        expect(result).to.equal(FUNCTIONS_SELECTOR.EXECUTE_ARRAY);
+        expect(result).to.equal(FUNCTIONS_SELECTOR.EXECUTE_BATCH);
       });
     });
 
@@ -49,7 +53,7 @@ describe('Constants Checker', () => {
 
       it('setData array selector', async () => {
         const result = await contract.getSetDataArraySelector();
-        expect(result).to.equal(FUNCTIONS_SELECTOR.SETDATA_ARRAY);
+        expect(result).to.equal(FUNCTIONS_SELECTOR.SETDATA_BATCH);
       });
     });
   });

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -96,7 +96,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
     valueToSend = ethers.utils.parseEther('50');
     await context.erc725X
       .connect(context.accounts.owner)
-      ['execute(uint256,address,uint256,bytes)'](OPERATION_TYPE.CALL, AddressZero, 0, '0x', {
+      .execute(OPERATION_TYPE.CALL, AddressZero, 0, '0x', {
         value: valueToSend,
       });
   });
@@ -166,7 +166,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -198,7 +198,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.anyone)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -230,7 +230,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               await context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -264,7 +264,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               await context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -297,7 +297,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -325,7 +325,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -354,7 +354,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -380,7 +380,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -410,7 +410,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -445,7 +445,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -474,7 +474,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -510,7 +510,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -553,7 +553,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -625,7 +625,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -660,7 +660,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -724,7 +724,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -748,7 +748,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -761,7 +761,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -798,7 +798,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -811,7 +811,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -843,7 +843,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -856,7 +856,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -892,7 +892,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -914,7 +914,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -938,7 +938,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -951,7 +951,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -988,7 +988,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1012,7 +1012,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1039,7 +1039,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1052,7 +1052,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1092,7 +1092,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1105,7 +1105,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1139,7 +1139,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1152,7 +1152,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1189,7 +1189,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1216,7 +1216,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1240,7 +1240,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1266,7 +1266,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1279,7 +1279,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1316,7 +1316,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1340,7 +1340,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1363,7 +1363,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1376,7 +1376,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1399,7 +1399,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1420,7 +1420,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               };
               const addressContractCreated = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1428,7 +1428,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
                 );
               await context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1446,7 +1446,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               // re-creating
               await context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1474,7 +1474,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1502,7 +1502,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1536,7 +1536,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1569,7 +1569,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const result = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256,address,uint256,bytes)'](
+                .callStatic.execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1601,7 +1601,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1633,7 +1633,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1659,7 +1659,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1694,7 +1694,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1727,7 +1727,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256,address,uint256,bytes)'](
+                  .execute(
                     txParams.Operation,
                     txParams.to,
                     txParams.value,
@@ -1757,7 +1757,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               await context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256,address,uint256,bytes)'](
+                .execute(
                   txParams.Operation,
                   txParams.to,
                   txParams.value,
@@ -1784,7 +1784,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
           await expect(
             context.erc725X
               .connect(context.accounts.owner)
-              ['execute(uint256,address,uint256,bytes)'](
+              .execute(
                 txParams.Operation,
                 txParams.to,
                 txParams.value,
@@ -1807,7 +1807,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
         await expect(
           context.erc725X
             .connect(context.accounts.owner)
-            ['execute(uint256[],address[],uint256[],bytes[])'](
+            .executeBatch(
               txParams.operations,
               txParams.targets,
               txParams.values,
@@ -1827,7 +1827,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
         await expect(
           context.erc725X
             .connect(context.accounts.owner)
-            ['execute(uint256[],address[],uint256[],bytes[])'](
+            .executeBatch(
               txParams.operations,
               txParams.targets,
               txParams.values,
@@ -1848,7 +1848,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
           await expect(
             context.erc725X
               .connect(context.accounts.owner)
-              ['execute(uint256[],address[],uint256[],bytes[])'](
+              .executeBatch(
                 txParams.operations,
                 txParams.targets,
                 txParams.values,
@@ -1868,7 +1868,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
           await expect(
             context.erc725X
               .connect(context.accounts.owner)
-              ['execute(uint256[],address[],uint256[],bytes[])'](
+              .executeBatch(
                 txParams.operations,
                 txParams.targets,
                 txParams.values,
@@ -1894,7 +1894,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256[],address[],uint256[],bytes[])'](
+                .executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -1936,7 +1936,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.anyone)
-                ['execute(uint256[],address[],uint256[],bytes[])'](
+                .executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -1977,7 +1977,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2017,7 +2017,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const result = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256[],address[],uint256[],bytes[])'](
+                .callStatic.executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2049,7 +2049,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2080,7 +2080,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2108,7 +2108,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const result = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256[],address[],uint256[],bytes[])'](
+                .callStatic.executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2120,7 +2120,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2162,7 +2162,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const result = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256[],address[],uint256[],bytes[])'](
+                .callStatic.executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2172,7 +2172,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               // real creation
               await context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256[],address[],uint256[],bytes[])'](
+                .executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2206,7 +2206,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2229,7 +2229,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
               const contractsAddresses = await context.erc725X
                 .connect(context.accounts.owner)
-                .callStatic['execute(uint256[],address[],uint256[],bytes[])'](
+                .callStatic.executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2239,7 +2239,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2287,7 +2287,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2319,7 +2319,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2365,7 +2365,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256[],address[],uint256[],bytes[])'](
+                .executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2386,7 +2386,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256[],address[],uint256[],bytes[])'](
+                .executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2412,7 +2412,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
             await expect(
               context.erc725X
                 .connect(context.accounts.owner)
-                ['execute(uint256[],address[],uint256[],bytes[])'](
+                .executeBatch(
                   txParams.Operations,
                   txParams.to,
                   txParams.values,
@@ -2436,7 +2436,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2464,7 +2464,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2492,7 +2492,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2516,7 +2516,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,
@@ -2541,7 +2541,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               await expect(
                 context.erc725X
                   .connect(context.accounts.owner)
-                  ['execute(uint256[],address[],uint256[],bytes[])'](
+                  .executeBatch(
                     txParams.Operations,
                     txParams.to,
                     txParams.values,

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -113,7 +113,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_MsgValueDisallowed');
       });
 
-      it('should revert when sending value to setData(..) Array', async () => {
+      it('should revert when sending value to setDataBatch(..)', async () => {
         let value = 100;
         const txParams = {
           dataKey: [ethers.utils.solidityKeccak256(['string'], ['FirstDataKey'])],

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -107,7 +107,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         await expect(
           context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue, {
+            .setData(txParams.dataKey, txParams.dataValue, {
               value: value,
             }),
         ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_MsgValueDisallowed');
@@ -123,14 +123,14 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         await expect(
           context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32[],bytes[])'](txParams.dataKey, txParams.dataValue, {
+            .setDataBatch(txParams.dataKey, txParams.dataValue, {
               value: value,
             }),
         ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_MsgValueDisallowed');
       });
     });
 
-    describe('When using setData(bytes32,bytes)', () => {
+    describe('When using setData', () => {
       describe('When owner is setting data', () => {
         it('should pass and emit DataChanged event', async () => {
           const txParams = {
@@ -141,12 +141,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           await expect(
             context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue),
+              .setData(txParams.dataKey, txParams.dataValue),
           )
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+          const fetchedData = await context.erc725Y.getData(
             txParams.dataKey,
           );
 
@@ -164,10 +164,10 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           await expect(
             context.erc725Y
               .connect(context.accounts.anyone)
-              ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue),
+              .setData(txParams.dataKey, txParams.dataValue),
           ).to.be.revertedWith('Ownable: caller is not the owner');
 
-          const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+          const fetchedData = await context.erc725Y.getData(
             txParams.dataKey,
           );
 
@@ -194,12 +194,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           await expect(
             erc725YWriter
               .connect(context.accounts.owner)
-              .callSetDataSingle(context.erc725Y.address, txParams.dataKey, txParams.dataValue),
+              .callSetData(context.erc725Y.address, txParams.dataKey, txParams.dataValue),
           )
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+          const fetchedData = await context.erc725Y.getData(
             txParams.dataKey,
           );
 
@@ -218,12 +218,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue),
+                .setData(txParams.dataKey, txParams.dataValue),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               txParams.dataKey,
             );
 
@@ -242,9 +242,9 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             // Setting for first time
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32,bytes)'](tx1Params.dataKey, tx1Params.dataValue);
+              .setData(tx1Params.dataKey, tx1Params.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx1Params.dataKey,
             );
 
@@ -259,12 +259,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32,bytes)'](tx2Params.dataKey, tx2Params.dataValue),
+                .setData(tx2Params.dataKey, tx2Params.dataValue),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx2Params.dataKey,
             );
 
@@ -283,9 +283,9 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             // Setting for first time
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32,bytes)'](tx1Params.dataKey, tx1Params.dataValue);
+              .setData(tx1Params.dataKey, tx1Params.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx1Params.dataKey,
             );
 
@@ -301,12 +301,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32,bytes)'](tx2Params.dataKey, tx2Params.dataValue),
+                .setData(tx2Params.dataKey, tx2Params.dataValue),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx2Params.dataKey,
             );
 
@@ -324,12 +324,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue),
+                .setData(txParams.dataKey, txParams.dataValue),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               txParams.dataKey,
             );
 
@@ -339,7 +339,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
       });
     });
 
-    describe('When using setData(bytes32[],bytes[])', () => {
+    describe('When using setDataBatch', () => {
       it('should revert if all parameters are empty arrays [] []', async () => {
         const dataKeys = [];
         const dataValues = [];
@@ -347,7 +347,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         await expect(
           context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32[],bytes[])'](dataKeys, dataValues),
+            .setDataBatch(dataKeys, dataValues),
         ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesEmptyArray');
       });
 
@@ -361,7 +361,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         await expect(
           context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32[],bytes[])'](dataKeys, dataValues),
+            .setDataBatch(dataKeys, dataValues),
         )
           .to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesLengthMismatch')
           .withArgs(dataKeys.length, dataValues.length);
@@ -377,12 +377,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           await expect(
             context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]),
+              .setDataBatch([txParams.dataKey], [txParams.dataValue]),
           )
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+          const fetchedData = await context.erc725Y.getData(
             txParams.dataKey,
           );
 
@@ -400,10 +400,10 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           await expect(
             context.erc725Y
               .connect(context.accounts.anyone)
-              ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]),
+              .setDataBatch([txParams.dataKey], [txParams.dataValue]),
           ).to.be.revertedWith('Ownable: caller is not the owner');
 
-          const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+          const fetchedData = await context.erc725Y.getData(
             txParams.dataKey,
           );
 
@@ -430,12 +430,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           await expect(
             erc725YWriter
               .connect(context.accounts.owner)
-              .callSetDataArray(context.erc725Y.address, [txParams.dataKey], [txParams.dataValue]),
+              .callSetDataBatch(context.erc725Y.address, [txParams.dataKey], [txParams.dataValue]),
           )
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+          const fetchedData = await context.erc725Y.getData(
             txParams.dataKey,
           );
 
@@ -454,12 +454,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]),
+                .setDataBatch([txParams.dataKey], [txParams.dataValue]),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               txParams.dataKey,
             );
 
@@ -477,9 +477,9 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             // Setting for first time
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32[],bytes[])']([tx1Params.dataKey], [tx1Params.dataValue]);
+              .setDataBatch([tx1Params.dataKey], [tx1Params.dataValue]);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx1Params.dataKey,
             );
 
@@ -494,12 +494,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32[],bytes[])']([tx2Params.dataKey], [tx2Params.dataValue]),
+                .setDataBatch([tx2Params.dataKey], [tx2Params.dataValue]),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx2Params.dataKey,
             );
 
@@ -517,9 +517,9 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             // Setting for first time
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32[],bytes[])']([tx1Params.dataKey], [tx1Params.dataValue]);
+              .setDataBatch([tx1Params.dataKey], [tx1Params.dataValue]);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx1Params.dataKey,
             );
 
@@ -535,12 +535,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32[],bytes[])']([tx2Params.dataKey], [tx2Params.dataValue]),
+                .setDataBatch([tx2Params.dataKey], [tx2Params.dataValue]),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               tx2Params.dataKey,
             );
 
@@ -558,12 +558,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]),
+                .setDataBatch([txParams.dataKey], [txParams.dataValue]),
             )
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.callStatic['getData(bytes32)'](
+            const fetchedData = await context.erc725Y.getData(
               txParams.dataKey,
             );
 
@@ -581,7 +581,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                ['setData(bytes32[],bytes[])'](
+                .setDataBatch(
                   [txParams.dataKey, txParams.dataKey],
                   [txParams.dataValue],
                 ),
@@ -609,12 +609,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
           await context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue);
+            .setData(txParams.dataKey, txParams.dataValue);
         });
         it('should pass', async () => {
           const result = await context.erc725Y
             .connect(context.accounts.owner)
-            .callStatic['getData(bytes32)'](txParams.dataKey);
+            .getData(txParams.dataKey);
 
           expect(result).to.equal(txParams.dataValue);
         });
@@ -629,12 +629,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
           await context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue);
+            .setData(txParams.dataKey, txParams.dataValue);
         });
         it('should pass', async () => {
           const result = await context.erc725Y
             .connect(context.accounts.anyone)
-            .callStatic['getData(bytes32)'](txParams.dataKey);
+            .getData(txParams.dataKey);
 
           expect(result).to.equal(txParams.dataValue);
         });
@@ -652,12 +652,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
           await context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue);
+            .setData(txParams.dataKey, txParams.dataValue);
         });
         it('should pass', async () => {
           const result = await erc725YReader
             .connect(context.accounts.anyone)
-            .callStatic.callGetDataSingle(context.erc725Y.address, txParams.dataKey);
+            .callStatic.callGetData(context.erc725Y.address, txParams.dataKey);
 
           expect(result).to.equal(txParams.dataValue);
         });
@@ -673,12 +673,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue);
+              .setData(txParams.dataKey, txParams.dataValue);
           });
           it('should pass', async () => {
             const result = await context.erc725Y
               .connect(context.accounts.owner)
-              .callStatic['getData(bytes32)'](txParams.dataKey);
+              .getData(txParams.dataKey);
 
             expect(result).to.equal(txParams.dataValue);
           });
@@ -693,19 +693,19 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32,bytes)'](txParams.dataKey, txParams.dataValue);
+              .setData(txParams.dataKey, txParams.dataValue);
           });
           it('should pass', async () => {
             const result = await context.erc725Y
               .connect(context.accounts.owner)
-              .callStatic['getData(bytes32)'](txParams.dataKey);
+              .getData(txParams.dataKey);
 
             expect(result).to.equal(txParams.dataValue);
           });
         });
       });
     });
-    describe('When using getData(bytes32[])', () => {
+    describe('When using getDataBatch(bytes32[])', () => {
       describe('When owner is setting data', () => {
         let txParams;
         beforeEach(async () => {
@@ -716,12 +716,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
           await context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]);
+            .setDataBatch([txParams.dataKey], [txParams.dataValue]);
         });
         it('should pass', async () => {
           const [result] = await context.erc725Y
             .connect(context.accounts.owner)
-            .callStatic['getData(bytes32[])']([txParams.dataKey]);
+            .getDataBatch([txParams.dataKey]);
 
           expect(result).to.equal(txParams.dataValue);
         });
@@ -736,12 +736,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
           await context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]);
+            .setDataBatch([txParams.dataKey], [txParams.dataValue]);
         });
         it('should pass', async () => {
           const [result] = await context.erc725Y
             .connect(context.accounts.anyone)
-            .callStatic['getData(bytes32[])']([txParams.dataKey]);
+            .getDataBatch([txParams.dataKey]);
 
           expect(result).to.equal(txParams.dataValue);
         });
@@ -759,12 +759,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
           await context.erc725Y
             .connect(context.accounts.owner)
-            ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]);
+            .setDataBatch([txParams.dataKey], [txParams.dataValue]);
         });
         it('should pass', async () => {
           const [result] = await erc725YReader
             .connect(context.accounts.anyone)
-            .callStatic.callGetDataArray(context.erc725Y.address, [txParams.dataKey]);
+            .callStatic.callGetDataBatch(context.erc725Y.address, [txParams.dataKey]);
 
           expect(result).to.equal(txParams.dataValue);
         });
@@ -780,12 +780,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]);
+              .setDataBatch([txParams.dataKey], [txParams.dataValue]);
           });
           it('should pass', async () => {
             const [result] = await context.erc725Y
               .connect(context.accounts.owner)
-              .callStatic['getData(bytes32[])']([txParams.dataKey]);
+              .getDataBatch([txParams.dataKey]);
 
             expect(result).to.equal(txParams.dataValue);
           });
@@ -801,12 +801,12 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32[],bytes[])']([txParams.dataKey], [txParams.dataValue]);
+              .setDataBatch([txParams.dataKey], [txParams.dataValue]);
           });
           it('should pass', async () => {
             const [result] = await context.erc725Y
               .connect(context.accounts.owner)
-              .callStatic['getData(bytes32[])']([txParams.dataKey]);
+              .getDataBatch([txParams.dataKey]);
 
             expect(result).to.equal(txParams.dataValue);
           });
@@ -824,7 +824,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
             await context.erc725Y
               .connect(context.accounts.owner)
-              ['setData(bytes32[],bytes[])'](
+              .setDataBatch(
                 [txParams.dataKey1, txParams.dataKey2],
                 [txParams.dataValue1, txParams.dataValue2],
               );
@@ -832,7 +832,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           it('should pass', async () => {
             const [result1, result2] = await context.erc725Y
               .connect(context.accounts.owner)
-              .callStatic['getData(bytes32[])']([txParams.dataKey1, txParams.dataKey2]);
+              .getDataBatch([txParams.dataKey1, txParams.dataKey2]);
 
             expect(result1).to.equal(txParams.dataValue1);
             expect(result2).to.equal(txParams.dataValue2);


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

## ♻️ Refactor

- Remove function overloading
- Change in the interfaceId
- Change in the way js libraries call ERC725 functions

Function overloading is not supported in many blockchain programming languages (vyper, cairo), which can create interoperability issues. To ensure language independence and promote interoperability, it was decided to remove function overloading and simply rename the functions to include the word "batch" when taking an array. 

### PR Checklist

- [ ] Wrote Tests **N/A**
- [ ] Wrote Documentation **N/A**
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
