### PR TITLE
feat: allow to fund ERC725 contracts on deployment

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -13,19 +13,20 @@ import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
 /**
  * @title ERC725 bundle
  * @author Fabian Vogelsteller <fabian@lukso.network>
- * @dev Bundles ERC725X and ERC725Y together into one smart contract
+ * @dev Bundles ERC725X and ERC725Y together into one smart contract.
+ * This implementation does not have by default a:
+ *  - `receive() external payable {}`
+ *  - or `fallback() external payable {}`
  */
 contract ERC725 is ERC725XCore, ERC725YCore {
     /**
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) {
+    constructor(address newOwner) payable {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }
-
-    // NOTE this implementation has not by default: receive() external payable {}
 
     /**
      * @inheritdoc ERC165

--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -7,7 +7,10 @@ import {ERC725InitAbstract} from "./ERC725InitAbstract.sol";
 /**
  * @title Deployable Proxy Implementation of ERC725 bundle
  * @author Fabian Vogelsteller <fabian@lukso.network>
- * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract
+ * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract.
+ * This implementation does not have by default a:
+ *  - `receive() external payable {}`
+ *  - or `fallback() external payable {}`
  */
 contract ERC725Init is ERC725InitAbstract {
     /**
@@ -21,9 +24,7 @@ contract ERC725Init is ERC725InitAbstract {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) public virtual initializer {
+    function initialize(address newOwner) public payable virtual initializer {
         ERC725InitAbstract._initialize(newOwner);
     }
-
-    // NOTE this implementation has not by default: receive() external payable {}
 }

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -17,7 +17,7 @@ contract ERC725X is ERC725XCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) {
+    constructor(address newOwner) payable {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -23,7 +23,7 @@ contract ERC725XInit is ERC725XInitAbstract {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) public virtual initializer {
+    function initialize(address newOwner) public payable virtual initializer {
         ERC725XInitAbstract._initialize(newOwner);
     }
 }

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -18,7 +18,7 @@ contract ERC725Y is ERC725YCore {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    constructor(address newOwner) {
+    constructor(address newOwner) payable {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         OwnableUnset._setOwner(newOwner);
     }

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -23,7 +23,7 @@ contract ERC725YInit is ERC725YInitAbstract {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) public virtual initializer {
+    function initialize(address newOwner) public payable virtual initializer {
         ERC725YInitAbstract._initialize(newOwner);
     }
 }

--- a/implementations/test/ERC725.test.ts
+++ b/implementations/test/ERC725.test.ts
@@ -28,12 +28,37 @@ describe('ERC725', () => {
           newOwner: ethers.constants.AddressZero,
         };
 
-        const contract = await new ERC725__factory(accounts[0]).deploy(accounts[0].address);
-
         await expect(
           new ERC725__factory(accounts[0]).deploy(deployParams.newOwner),
         ).to.be.revertedWith('Ownable: new owner is the zero address');
       });
+
+      it("should deploy the contract with the owner's address", async () => {
+        const accounts = await ethers.getSigners();
+
+        const deployParams = {
+          newOwner: accounts[0].address,
+        };
+
+        const contract = await new ERC725__factory(accounts[0]).deploy(deployParams.newOwner);
+
+        expect(await contract.owner()).to.equal(deployParams.newOwner);
+      })
+
+      it("should deploy and fund the contract with `msg.value`", async () => {
+        const accounts = await ethers.getSigners();
+
+        const deployParams = {
+          newOwner: accounts[0].address,
+          funding: ethers.utils.parseEther('10'),
+        };
+
+        const contract = await new ERC725__factory(accounts[0]).deploy(deployParams.newOwner, {
+          value: deployParams.funding,
+        });
+
+        expect(await ethers.provider.getBalance(contract.address)).to.equal(deployParams.funding);
+      })
     });
   });
 
@@ -79,6 +104,21 @@ describe('ERC725', () => {
           context.erc725['initialize(address)'](ethers.constants.AddressZero),
         ).to.be.revertedWith('Ownable: new owner is the zero address');
       });
+
+      it("should initialize the contract with the owner's address", async () => {
+        await context.erc725['initialize(address)'](context.deployParams.newOwner);
+        expect(await context.erc725.owner()).to.equal(context.deployParams.newOwner);
+      })
+
+      it("should initialize and fund the contract with `msg.value`", async () => {
+        const funding = ethers.utils.parseEther('10');
+
+        await context.erc725['initialize(address)'](context.deployParams.newOwner, {
+          value: funding,
+        });
+
+        expect(await ethers.provider.getBalance(context.erc725.address)).to.equal(funding);
+      })
     });
   });
 });

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
+import { BigNumber } from "ethers"
 
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { AddressZero } from '@ethersproject/constants';
@@ -73,6 +74,7 @@ export const getNamedAccounts = async (): Promise<ERC725XTestAccounts> => {
 
 export type ERC725XDeployParams = {
   newOwner: string;
+  funding?: BigNumber;
 };
 
 export type ERC725XTestContext = {
@@ -2586,5 +2588,9 @@ export const shouldInitializeLikeERC725X = (
     it('should have set the correct owner', async () => {
       expect(await context.erc725X.callStatic.owner()).to.equal(context.deployParams.newOwner);
     });
+
+    it("should have funded the contract with `msg.value` when `initialize(...)` was called", async () => {
+      expect()
+    })
   });
 };

--- a/implementations/test/ERC725X.test.ts
+++ b/implementations/test/ERC725X.test.ts
@@ -38,6 +38,21 @@ describe('ERC725X', () => {
         ).to.be.revertedWith('Ownable: new owner is the zero address');
       });
 
+      it("should deploy and fund the contract with `msg.value`", async () => {
+        const accounts = await getNamedAccounts();
+
+        const deployParams = {
+          newOwner: accounts.owner.address,
+          funding: ethers.utils.parseEther('10'),
+        };
+
+        const contract = await new ERC725X__factory(accounts.owner).deploy(deployParams.newOwner, {
+          value: deployParams.funding,
+        });
+
+        expect(await ethers.provider.getBalance(contract.address)).to.equal(deployParams.funding);
+      })
+
       describe('once the contract was deployed', () => {
         let context: ERC725XTestContext;
 
@@ -67,6 +82,7 @@ describe('ERC725X', () => {
 
       const deployParams = {
         newOwner: accounts.owner.address,
+        funding: ethers.utils.parseEther('10'),
       };
 
       const erc725XBase = await new ERC725XInit__factory(accounts.owner).deploy();
@@ -78,7 +94,9 @@ describe('ERC725X', () => {
     };
 
     const initializeProxy = async (context: ERC725XTestContext) => {
-      return context.erc725X['initialize(address)'](context.deployParams.newOwner);
+      return context.erc725X['initialize(address)'](context.deployParams.newOwner, {
+        value: context.deployParams.funding,
+      });
     };
 
     describe('when deploying the base implementation contract', () => {

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
+import { BigNumber } from 'ethers';
 
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { AddressZero } from '@ethersproject/constants';
@@ -32,6 +33,7 @@ export const getNamedAccounts = async (): Promise<ERC725YTestAccounts> => {
 
 export type ERC725YDeployParams = {
   newOwner: string;
+  funding?: BigNumber;
 };
 
 export type ERC725YTestContext = {
@@ -146,9 +148,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.getData(
-            txParams.dataKey,
-          );
+          const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
           expect(fetchedData).to.equal(txParams.dataValue);
         });
@@ -167,9 +167,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .setData(txParams.dataKey, txParams.dataValue),
           ).to.be.revertedWith('Ownable: caller is not the owner');
 
-          const fetchedData = await context.erc725Y.getData(
-            txParams.dataKey,
-          );
+          const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
           expect(fetchedData).to.equal('0x');
         });
@@ -199,9 +197,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.getData(
-            txParams.dataKey,
-          );
+          const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
           expect(fetchedData).to.equal(txParams.dataValue);
         });
@@ -223,9 +219,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              txParams.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
             expect(fetchedData).to.equal(txParams.dataValue);
           });
@@ -244,9 +238,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .connect(context.accounts.owner)
               .setData(tx1Params.dataKey, tx1Params.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx1Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx1Params.dataKey);
 
             expect(fetchedData).to.equal(tx1Params.dataValue);
           });
@@ -264,9 +256,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx2Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx2Params.dataKey);
 
             expect(fetchedData).to.equal(tx2Params.dataValue);
           });
@@ -285,9 +275,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .connect(context.accounts.owner)
               .setData(tx1Params.dataKey, tx1Params.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx1Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx1Params.dataKey);
 
             expect(fetchedData).to.equal(tx1Params.dataValue);
           });
@@ -306,9 +294,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx2Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx2Params.dataKey);
 
             expect(fetchedData).to.equal(tx2Params.dataValue);
           });
@@ -329,9 +315,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              txParams.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
             expect(fetchedData).to.equal(txParams.dataValue);
           });
@@ -345,9 +329,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         const dataValues = [];
 
         await expect(
-          context.erc725Y
-            .connect(context.accounts.owner)
-            .setDataBatch(dataKeys, dataValues),
+          context.erc725Y.connect(context.accounts.owner).setDataBatch(dataKeys, dataValues),
         ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesEmptyArray');
       });
 
@@ -359,11 +341,8 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
         const dataValues = [];
 
         await expect(
-          context.erc725Y
-            .connect(context.accounts.owner)
-            .setDataBatch(dataKeys, dataValues),
-        )
-          .to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesLengthMismatch')
+          context.erc725Y.connect(context.accounts.owner).setDataBatch(dataKeys, dataValues),
+        ).to.be.revertedWithCustomError(context.erc725Y, 'ERC725Y_DataKeysValuesLengthMismatch');
       });
 
       describe('When owner is setting data', () => {
@@ -381,9 +360,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.getData(
-            txParams.dataKey,
-          );
+          const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
           expect(fetchedData).to.equal(txParams.dataValue);
         });
@@ -402,9 +379,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .setDataBatch([txParams.dataKey], [txParams.dataValue]),
           ).to.be.revertedWith('Ownable: caller is not the owner');
 
-          const fetchedData = await context.erc725Y.getData(
-            txParams.dataKey,
-          );
+          const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
           expect(fetchedData).to.equal('0x');
         });
@@ -434,9 +409,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             .to.emit(context.erc725Y, 'DataChanged')
             .withArgs(txParams.dataKey, txParams.dataValue);
 
-          const fetchedData = await context.erc725Y.getData(
-            txParams.dataKey,
-          );
+          const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
           expect(fetchedData).to.equal(txParams.dataValue);
         });
@@ -458,9 +431,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              txParams.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
             expect(fetchedData).to.equal(txParams.dataValue);
           });
@@ -478,9 +449,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .connect(context.accounts.owner)
               .setDataBatch([tx1Params.dataKey], [tx1Params.dataValue]);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx1Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx1Params.dataKey);
 
             expect(fetchedData).to.equal(tx1Params.dataValue);
           });
@@ -498,9 +467,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx2Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx2Params.dataKey);
 
             expect(fetchedData).to.equal(tx2Params.dataValue);
           });
@@ -518,9 +485,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .connect(context.accounts.owner)
               .setDataBatch([tx1Params.dataKey], [tx1Params.dataValue]);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx1Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx1Params.dataKey);
 
             expect(fetchedData).to.equal(tx1Params.dataValue);
           });
@@ -539,9 +504,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(tx2Params.dataKey, tx2Params.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              tx2Params.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(tx2Params.dataKey);
 
             expect(fetchedData).to.equal(tx2Params.dataValue);
           });
@@ -562,9 +525,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
               .to.emit(context.erc725Y, 'DataChanged')
               .withArgs(txParams.dataKey, txParams.dataValue);
 
-            const fetchedData = await context.erc725Y.getData(
-              txParams.dataKey,
-            );
+            const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
             expect(fetchedData).to.equal(txParams.dataValue);
           });
@@ -580,15 +541,11 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             await expect(
               context.erc725Y
                 .connect(context.accounts.owner)
-                .setDataBatch(
-                  [txParams.dataKey, txParams.dataKey],
-                  [txParams.dataValue],
-                ),
-            )
-              .to.be.revertedWithCustomError(
-                context.erc725Y,
-                'ERC725Y_DataKeysValuesLengthMismatch',
-              )
+                .setDataBatch([txParams.dataKey, txParams.dataKey], [txParams.dataValue]),
+            ).to.be.revertedWithCustomError(
+              context.erc725Y,
+              'ERC725Y_DataKeysValuesLengthMismatch',
+            );
           });
         });
       });
@@ -857,16 +814,22 @@ export const shouldInitializeLikeERC725Y = (
   });
 
   describe('when the contract was initialized', () => {
+    it('should have set the correct owner', async () => {
+      expect(await context.erc725Y.callStatic.owner()).to.be.equal(context.deployParams.newOwner);
+    });
+
+    it('should have deployed and funded the contract with `msg.value`', async () => {
+      expect(await ethers.provider.getBalance(context.erc725Y.address)).to.equal(
+        context.deployParams.funding,
+      );
+    });
+
     it('should have registered the ERC165 interface', async () => {
       expect(await context.erc725Y.supportsInterface(INTERFACE_ID.ERC165)).to.be.true;
     });
 
     it('should have registered the ERC725Y interface', async () => {
       expect(await context.erc725Y.supportsInterface(INTERFACE_ID.ERC725Y));
-    });
-
-    it('should have set the correct owner', async () => {
-      expect(await context.erc725Y.callStatic.owner()).to.be.equal(context.deployParams.newOwner);
     });
   });
 };

--- a/implementations/test/ERC725Y.test.ts
+++ b/implementations/test/ERC725Y.test.ts
@@ -18,9 +18,12 @@ describe('ERC725Y', () => {
 
       const deployParams = {
         newOwner: accounts.owner.address,
+        funding: ethers.utils.parseEther('10'),
       };
 
-      const erc725Y = await new ERC725Y__factory(accounts.owner).deploy(deployParams.newOwner);
+      const erc725Y = await new ERC725Y__factory(accounts.owner).deploy(deployParams.newOwner, {
+        value: deployParams.funding,
+      });
 
       return { accounts, erc725Y, deployParams };
     };
@@ -67,6 +70,7 @@ describe('ERC725Y', () => {
 
       const deployParams = {
         newOwner: accounts.owner.address,
+        funding: ethers.utils.parseEther('10'),
       };
 
       const erc725YBase = await new ERC725YInit__factory(accounts.owner).deploy();
@@ -78,7 +82,9 @@ describe('ERC725Y', () => {
     };
 
     const initializeProxy = async (context: ERC725YTestContext) => {
-      return context.erc725Y['initialize(address)'](context.deployParams.newOwner);
+      return context.erc725Y['initialize(address)'](context.deployParams.newOwner, {
+        value: context.deployParams.funding,
+      });
     };
 
     describe('when deploying the base implementation contract', () => {


### PR DESCRIPTION
# What does this PR introduce?

## 🚀 Feature

Allow the contract to be funded on deployment via `constructor` or `initialize(...) public` functions.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
