### PR TITLE
refactor: use explicit `return` statements in `ERC725XCore`

### DIFF
--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -175,7 +175,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = target.call{value: value}(data);
-        result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
+        return Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
     }
 
     /**
@@ -192,7 +192,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = target.staticcall(data);
-        result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
+        return Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
     }
 
     /**
@@ -209,7 +209,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
 
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory returnData) = target.delegatecall(data);
-        result = Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
+        return Address.verifyCallResult(success, returnData, "ERC725X: Unknown Error");
     }
 
     /**
@@ -240,8 +240,8 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
             revert ERC725X_ContractDeploymentFailed();
         }
 
-        newContract = abi.encodePacked(contractAddress);
         emit ContractCreated(OPERATION_1_CREATE, contractAddress, value, bytes32(0));
+        return abi.encodePacked(contractAddress);
     }
 
     /**
@@ -262,7 +262,7 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
         bytes memory bytecode = BytesLib.slice(creationCode, 0, creationCode.length - 32);
         address contractAddress = Create2.deploy(value, salt, bytecode);
 
-        newContract = abi.encodePacked(contractAddress);
         emit ContractCreated(OPERATION_2_CREATE2, contractAddress, value, salt);
+        return abi.encodePacked(contractAddress);
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

Use explicit `return` statements inside the `internal` functions of `ERC725XCore`, so to distinguish visually in the code what is being returned by the function.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests (N/A)
- [ ] Wrote Documentation (N/A)
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
