### PR TITLE
refactor!: remove deprecated constants for overloaded function selectors

### DIFF
--- a/implementations/constants.js
+++ b/implementations/constants.js
@@ -12,13 +12,6 @@ const OPERATION_TYPE = {
   DELEGATECALL: 4,
 };
 
-const FUNCTIONS_SELECTOR = {
-  EXECUTE: '0x44c028fe',
-  EXECUTE_BATCH: '0x31858452',
-  SETDATA: '0x7f23690c',
-  SETDATA_BATCH: '0x97902421',
-};
-
 const Errors = {
   ERC725X: {
     '0x0df9a8f8': {
@@ -116,6 +109,5 @@ module.exports = {
   INTERFACE_ID,
   OPERATION_TYPE,
   Errors,
-  EventSignatures,
-  FUNCTIONS_SELECTOR,
+  EventSignatures
 };

--- a/implementations/contracts/constants.sol
+++ b/implementations/contracts/constants.sol
@@ -5,17 +5,9 @@ pragma solidity ^0.8.0;
 bytes4 constant _INTERFACEID_ERC725X = 0x7545acac;
 bytes4 constant _INTERFACEID_ERC725Y = 0x629aa694;
 
-// ERC725X function selectors
-bytes4 constant EXECUTE_SELECTOR = 0x44c028fe;
-bytes4 constant EXECUTE_BATCH_SELECTOR = 0x31858452;
-
 // ERC725X OPERATION TYPES
 uint256 constant OPERATION_0_CALL = 0;
 uint256 constant OPERATION_1_CREATE = 1;
 uint256 constant OPERATION_2_CREATE2 = 2;
 uint256 constant OPERATION_3_STATICCALL = 3;
 uint256 constant OPERATION_4_DELEGATECALL = 4;
-
-// ERC725Y function selectors
-bytes4 constant SETDATA_SELECTOR = 0x7f23690c;
-bytes4 constant SETDATA_BATCH_SELECTOR = 0x97902421;

--- a/implementations/contracts/helpers/ConstantsChecker.sol
+++ b/implementations/contracts/helpers/ConstantsChecker.sol
@@ -27,36 +27,4 @@ contract ConstantsChecker {
         );
         return type(IERC725Y).interfaceId;
     }
-
-    function getExecuteSelector() public pure returns (bytes4) {
-        require(
-            EXECUTE_SELECTOR == IERC725X.execute.selector,
-            "hardcoded EXECUTE_SELECTOR in `constants.sol` does not match `IERC725X.execute.selector`"
-        );
-        return IERC725X.execute.selector;
-    }
-
-    function getExecuteArraySelector() public pure returns (bytes4) {
-        require(
-            EXECUTE_BATCH_SELECTOR == IERC725X.executeBatch.selector,
-            "hardcoded EXECUTE_BATCH_SELECTOR in `constants.sol` does not match `IERC725X.execute.selector`"
-        );
-        return IERC725X.executeBatch.selector;
-    }
-
-    function getSetDataSelector() public pure returns (bytes4) {
-        require(
-            SETDATA_SELECTOR == IERC725Y.setData.selector,
-            "hardcoded SETDATA_SELECTOR in `constants.sol` does not match `IERC725Y.setData.selector`"
-        );
-        return IERC725Y.setData.selector;
-    }
-
-    function getSetDataArraySelector() public pure returns (bytes4) {
-        require(
-            SETDATA_BATCH_SELECTOR == IERC725Y.setDataBatch.selector,
-            "hardcoded SETDATA_BATCH_SELECTOR in `constants.sol` does not match `IERC725Y.setData.selector`"
-        );
-        return IERC725Y.setDataBatch.selector;
-    }
 }

--- a/implementations/test/ConstantsChecker.test.ts
+++ b/implementations/test/ConstantsChecker.test.ts
@@ -5,9 +5,9 @@ import { ethers } from 'hardhat';
 import { ConstantsChecker, ConstantsChecker__factory } from '../types';
 
 // utils
-import { INTERFACE_ID, FUNCTIONS_SELECTOR } from '../constants';
+import { INTERFACE_ID } from '../constants';
 
-describe('Constants Checker', () => {
+describe('Calculating ERC165InterfaceIds', () => {
   let accounts: SignerWithAddress[];
   let contract: ConstantsChecker;
 
@@ -16,41 +16,13 @@ describe('Constants Checker', () => {
     contract = await new ConstantsChecker__factory(accounts[0]).deploy();
   });
 
-  describe('Calculating ERC165InterfaceIds', () => {
-    it('ERC725X', async () => {
-      const result = await contract.getERC725XInterfaceID();
-      expect(result).to.equal(INTERFACE_ID.ERC725X);
-    });
-
-    it('ERC725Y', async () => {
-      const result = await contract.getERC725YInterfaceID();
-      expect(result).to.equal(INTERFACE_ID.ERC725Y);
-    });
+  it('ERC725X', async () => {
+    const result = await contract.getERC725XInterfaceID();
+    expect(result).to.equal(INTERFACE_ID.ERC725X);
   });
 
-  describe('Calculating Functions selectors', () => {
-    describe('ERC725X', () => {
-      it('execute selector', async () => {
-        const result = await contract.getExecuteSelector();
-        expect(result).to.equal(FUNCTIONS_SELECTOR.EXECUTE);
-      });
-
-      it('execute array selector', async () => {
-        const result = await contract.getExecuteArraySelector();
-        expect(result).to.equal(FUNCTIONS_SELECTOR.EXECUTE_BATCH);
-      });
-    });
-
-    describe('ERC725Y', () => {
-      it('setData selector', async () => {
-        const result = await contract.getSetDataSelector();
-        expect(result).to.equal(FUNCTIONS_SELECTOR.SETDATA);
-      });
-
-      it('setData array selector', async () => {
-        const result = await contract.getSetDataArraySelector();
-        expect(result).to.equal(FUNCTIONS_SELECTOR.SETDATA_BATCH);
-      });
-    });
+  it('ERC725Y', async () => {
+    const result = await contract.getERC725YInterfaceID();
+    expect(result).to.equal(INTERFACE_ID.ERC725Y);
   });
 });


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

**Deprecate constants `EXECURTE_SELECTOR`, `EXECUTE_BATCH_SELECTOR`, `SETDATA_SELECTOR` and `SETDATA_BATCH_SELECTOR`.**

Prior to v5.0.0, it was not possible to access the selector for the overloaded functions with `.selector` syntax in Solidity.
Therefore, these selectors were saved in solidity `bytes4 constant`.

Since v5.0.0, overloaded functions have been removed, and it now possible to access these selectors via `setData.selector` and `setDataBatch.selector` in Solidity.

Remove these constants from the `constants.sol` file.

### PR Checklist


- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
