### PR TITLE
build: upgrade to `0.8.17` for default solc compiler version

### DIFF
--- a/implementations/hardhat.config.ts
+++ b/implementations/hardhat.config.ts
@@ -15,7 +15,7 @@ import "@nomicfoundation/hardhat-toolbox";
 import "hardhat-packager";
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.10",
+  solidity: "0.8.17",
   packager: {
     contracts: [
       "ERC725X",


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build

- Bump Solidity compiler version from `0.8.10` -> `0.8.17` in `hardhat.config.ts`

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
