### PR TITLE
build: upgrade `@openzeppelin/contracts` to 4.9.2

### DIFF
--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -9,8 +9,8 @@
       "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.9.1",
-        "@openzeppelin/contracts-upgradeable": "^4.9.1",
+        "@openzeppelin/contracts": "^4.9.2",
+        "@openzeppelin/contracts-upgradeable": "^4.9.2",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -34,8 +34,8 @@
   "author": "Fabian Vogelsteller <fabian@lukso.network>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@openzeppelin/contracts": "^4.9.1",
-    "@openzeppelin/contracts-upgradeable": "^4.9.1",
+    "@openzeppelin/contracts": "^4.9.2",
+    "@openzeppelin/contracts-upgradeable": "^4.9.2",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build

Bump default version of `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradable` from `4.9.1` to `4.9.2` in `package.json`.
