### PR TITLE
chore: prepare release 5.2.0

### DIFF
--- a/implementations/CHANGELOG.md
+++ b/implementations/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.2.0](https://github.com/ERC725Alliance/ERC725/compare/v5.1.0...v5.2.0) (2023-07-25)
+
+- Improve Natspec comments of smart contracts ([#229](https://github.com/ERC725Alliance/ERC725/pull/229))
+
 ## [5.1.0](https://github.com/ERC725Alliance/ERC725/compare/v5.0.0...v5.1.0) (2023-06-21)
 
 ### Features

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/smart-contracts",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.2",

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "ERC725 contract implementations",
   "homepage": "https://erc725alliance.org",
   "repository": {


### PR DESCRIPTION
# What does this PR introduce?

Prepare a new minor release that includes better Natspec comments, so that they can better used to render developer docs in package that use `@erc725/smart-contracts` as a dependency.
See https://github.com/lukso-network/lsp-smart-contracts/pull/638

- Bump version in `package.json` and `package-lock.json` from `5.1.0` > `5.2.0`
- Add release details in `CHANGELOG.md`
