### PR TITLE
build: upgrade OpenZeppelin contracts to 4.9.3

### DIFF
--- a/implementations/CHANGELOG.md
+++ b/implementations/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### [5.2.0](https://github.com/ERC725Alliance/ERC725/compare/v5.1.0...v5.2.0) (2023-07-25)
 
 - Improve Natspec comments of smart contracts ([#229](https://github.com/ERC725Alliance/ERC725/pull/229))
+- Bump version of `@openzeppelin/contracts` dependency from `4.9.2` to `4.9.3`
 
 ## [5.1.0](https://github.com/ERC725Alliance/ERC725/compare/v5.0.0...v5.1.0) (2023-06-21)
 

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -9,8 +9,8 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.9.2",
-        "@openzeppelin/contracts-upgradeable": "^4.9.2",
+        "@openzeppelin/contracts": "^4.9.3",
+        "@openzeppelin/contracts-upgradeable": "^4.9.3",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -34,8 +34,8 @@
   "author": "Fabian Vogelsteller <fabian@lukso.network>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@openzeppelin/contracts": "^4.9.2",
-    "@openzeppelin/contracts-upgradeable": "^4.9.2",
+    "@openzeppelin/contracts": "^4.9.3",
+    "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build

- Bump version of `@openzeppelin/contracts` dependency from `4.9.2` to `4.9.3` in `package.json`