### PR TITLE
refactor: use custom error for `onlyOwner` and `address(0)` check

### DIFF
--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -29,7 +29,7 @@ jobs:
             "0.8.14",
             "0.8.15",
             "0.8.16",
-            # "0.8.17", # skipped as default in hardhat.config.
+            # "0.8.17", # skipped as default in hardhat.config.ts
             "0.8.18",
             "0.8.19",
             "0.8.20",
@@ -58,6 +58,7 @@ jobs:
 
       - name: Compile Smart Contracts
         run: |
-          solc contracts/**/*.sol \
-              @openzeppelin/=node_modules/@openzeppelin/ --allow-paths $(pwd)/node_modules/ \
-              solidity-bytes-utils/=node_modules/solidity-bytes-utils/
+          solc contracts/**/*.sol --allow-paths $(pwd)/node_modules/ \
+              @openzeppelin/=$(pwd)/node_modules/@openzeppelin/ \
+              solidity-bytes-utils/=$(pwd)/node_modules/solidity-bytes-utils/ \
+              ../=$(pwd)/contracts/

--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -17,16 +17,23 @@ jobs:
     strategy:
       matrix:
         solc: [
+            "0.8.5",
+            "0.8.6",
+            "0.8.7",
             "0.8.8",
             "0.8.9",
-            # "0.8.10" skipped as default in hardhat.config.ts
+            "0.8.10",
             "0.8.11",
             "0.8.12",
             "0.8.13",
             "0.8.14",
             "0.8.15",
             "0.8.16",
-            "0.8.17",
+            # "0.8.17", # skipped as default in hardhat.config.
+            "0.8.18",
+            "0.8.19",
+            "0.8.20",
+            "0.8.21"
           ]
     steps:
       - uses: actions/checkout@v3
@@ -52,5 +59,5 @@ jobs:
       - name: Compile Smart Contracts
         run: |
           solc contracts/**/*.sol \
-              @openzeppelin/=node_modules/@openzeppelin/ \
+              @openzeppelin/=node_modules/@openzeppelin/ --allow-paths $(pwd)/node_modules/ \
               solidity-bytes-utils/=node_modules/solidity-bytes-utils/

--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -10,6 +10,9 @@ import {ERC725YCore} from "./ERC725YCore.sol";
 // constants
 import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
+
 /**
  * @title ERC725 bundle.
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -27,10 +30,9 @@ contract ERC725 is ERC725XCore, ERC725YCore {
      * - `initialOwner` CANNOT be the zero address.
      */
     constructor(address initialOwner) payable {
-        require(
-            initialOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (initialOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         OwnableUnset._setOwner(initialOwner);
     }
 

--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.5;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.5;
 
 // modules
 import {ERC725InitAbstract} from "./ERC725InitAbstract.sol";

--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // modules
 import {ERC725InitAbstract} from "./ERC725InitAbstract.sol";

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -13,6 +13,9 @@ import {ERC725YCore} from "./ERC725YCore.sol";
 // constants
 import {_INTERFACEID_ERC725X, _INTERFACEID_ERC725Y} from "./constants.sol";
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
+
 /**
  * @title Inheritable Proxy Implementation of ERC725 bundle
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -35,10 +38,9 @@ abstract contract ERC725InitAbstract is
     function _initialize(
         address initialOwner
     ) internal virtual onlyInitializing {
-        require(
-            initialOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (initialOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         OwnableUnset._setOwner(initialOwner);
     }
 

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.5;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 // modules
 import {OwnableUnset} from "./custom/OwnableUnset.sol";

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -5,6 +5,9 @@ pragma solidity ^0.8.0;
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
+
 /**
  * @title Deployable implementation with `constructor` of ERC725X, a generic executor.
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -23,10 +26,9 @@ contract ERC725X is ERC725XCore {
      * - `initialOwner` CANNOT be the zero address.
      */
     constructor(address initialOwner) payable {
-        require(
-            initialOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (initialOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         OwnableUnset._setOwner(initialOwner);
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 // interfaces
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 // modules
 import {ERC725XInitAbstract} from "./ERC725XInitAbstract.sol";

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -8,6 +8,9 @@ import {
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
+
 /**
  * @title Inheritable Proxy Implementation of ERC725X, a generic executor.
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -27,10 +30,9 @@ abstract contract ERC725XInitAbstract is Initializable, ERC725XCore {
     function _initialize(
         address initialOwner
     ) internal virtual onlyInitializing {
-        require(
-            initialOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (initialOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         OwnableUnset._setOwner(initialOwner);
     }
 }

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 // modules
 import {

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -6,6 +6,9 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725YCore} from "./ERC725YCore.sol";
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
+
 /**
  * @title Deployable implementation with `constructor` of ERC725Y, a generic data key/value store.
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -22,10 +25,9 @@ contract ERC725Y is ERC725YCore {
      * - `initialOwner` CANNOT be the zero address.
      */
     constructor(address initialOwner) payable {
-        require(
-            initialOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (initialOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         OwnableUnset._setOwner(initialOwner);
     }
 }

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // interfaces
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // modules
 import {ERC725YInitAbstract} from "./ERC725YInitAbstract.sol";

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -8,6 +8,9 @@ import {
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725YCore} from "./ERC725YCore.sol";
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
+
 /**
  * @title Inheritable Proxy Implementation of ERC725Y, a generic data key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -25,10 +28,9 @@ abstract contract ERC725YInitAbstract is Initializable, ERC725YCore {
     function _initialize(
         address initialOwner
     ) internal virtual onlyInitializing {
-        require(
-            initialOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (initialOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         OwnableUnset._setOwner(initialOwner);
     }
 }

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // modules
 import {

--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.0;
 
 // errors
-import {OwnableCannotSetZeroAddressAsOwner} from "../errors.sol";
+import {
+    OwnableCannotSetZeroAddressAsOwner,
+    OwnableCallerNotTheOwner
+} from "../errors.sol";
 
 /**
  * @title OwnableUnset
@@ -60,7 +63,9 @@ abstract contract OwnableUnset {
      * @dev Throws if the sender is not the owner.
      */
     function _checkOwner() internal view virtual {
-        require(owner() == msg.sender, "Ownable: caller is not the owner");
+        if (owner() != msg.sender) {
+            revert OwnableCallerNotTheOwner(msg.sender);
+        }
     }
 
     /**

--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// errors
+import {OwnableCannotSetZeroAddressAsOwner} from "../errors.sol";
+
 /**
  * @title OwnableUnset
  * @dev modified version of OpenZeppelin implementation, where:
@@ -47,10 +50,9 @@ abstract contract OwnableUnset {
      * Can only be called by the current owner.
      */
     function transferOwnership(address newOwner) public virtual onlyOwner {
-        require(
-            newOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        if (newOwner == address(0)) {
+            revert OwnableCannotSetZeroAddressAsOwner();
+        }
         _setOwner(newOwner);
     }
 

--- a/implementations/contracts/custom/OwnableUnset.sol
+++ b/implementations/contracts/custom/OwnableUnset.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 // errors
 import {

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /**
- * @dev Reverts whn trying to set `address(0)` as the contract owner when deploying the contract, 
+ * @dev Reverts whn trying to set `address(0)` as the contract owner when deploying the contract,
  * initializing it or transferring ownership of the contract.
  */
 error OwnableCannotSetZeroAddressAsOwner();

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.0;
 
 /**
+ * @dev Reverts whn trying to set `address(0)` as the contract owner when deploying the contract, 
+ * initializing it or transferring ownership of the contract.
+ */
+error OwnableCannotSetZeroAddressAsOwner();
+
+/**
  * @dev Reverts when trying to send more native tokens `value` than available in current `balance`.
  * @param balance The balance of native tokens of the ERC725X smart contract.
  * @param value The amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` that is greater than the contract's `balance`.

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.4;
 error OwnableCannotSetZeroAddressAsOwner();
 
 /**
- * @dev Reverts when the only the owner is allowed to call the function.
+ * @dev Reverts when only the owner is allowed to call the function.
  * @param callerAddress The address that tried to make the call.
  */
 error OwnableCallerNotTheOwner(address callerAddress);

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 /**
  * @dev Reverts when trying to set `address(0)` as the contract owner when deploying the contract,

--- a/implementations/contracts/errors.sol
+++ b/implementations/contracts/errors.sol
@@ -2,10 +2,16 @@
 pragma solidity ^0.8.0;
 
 /**
- * @dev Reverts whn trying to set `address(0)` as the contract owner when deploying the contract,
+ * @dev Reverts when trying to set `address(0)` as the contract owner when deploying the contract,
  * initializing it or transferring ownership of the contract.
  */
 error OwnableCannotSetZeroAddressAsOwner();
+
+/**
+ * @dev Reverts when the only the owner is allowed to call the function.
+ * @param callerAddress The address that tried to make the call.
+ */
+error OwnableCallerNotTheOwner(address callerAddress);
 
 /**
  * @dev Reverts when trying to send more native tokens `value` than available in current `balance`.

--- a/implementations/test/ERC725.test.ts
+++ b/implementations/test/ERC725.test.ts
@@ -30,9 +30,12 @@ describe('ERC725', () => {
           newOwner: ethers.constants.AddressZero,
         };
 
-        await expect(
-          new ERC725__factory(accounts[0]).deploy(deployParams.newOwner),
-        ).to.be.revertedWith('Ownable: new owner is the zero address');
+        const contractToDeploy = new ERC725__factory(accounts[0]);
+
+        await expect(contractToDeploy.deploy(deployParams.newOwner)).to.be.revertedWithCustomError(
+          contractToDeploy,
+          'OwnableCannotSetZeroAddressAsOwner',
+        );
       });
 
       it("should deploy the contract with the owner's address", async () => {
@@ -108,7 +111,7 @@ describe('ERC725', () => {
       it('should revert when initializing with address(0) as owner', async () => {
         await expect(
           context.erc725['initialize(address)'](ethers.constants.AddressZero),
-        ).to.be.revertedWith('Ownable: new owner is the zero address');
+        ).to.be.revertedWithCustomError(context.erc725, 'OwnableCannotSetZeroAddressAsOwner');
       });
 
       it("should initialize the contract with the owner's address", async () => {

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -118,6 +118,14 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
 
         expect(accountOwner).to.equal(context.accounts.anyone.address);
       });
+
+      it('should revert when transferring ownership to `address(0)`', async () => {
+        await expect(
+          context.erc725X
+            .connect(context.accounts.owner)
+            .transferOwnership(ethers.constants.AddressZero),
+        ).to.be.revertedWithCustomError(context.erc725X, 'OwnableCannotSetZeroAddressAsOwner');
+      });
     });
 
     describe('When non-owner is transferring ownership', () => {

--- a/implementations/test/ERC725X.behaviour.ts
+++ b/implementations/test/ERC725X.behaviour.ts
@@ -126,7 +126,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
           context.erc725X
             .connect(context.accounts.anyone)
             .transferOwnership(context.accounts.anyone.address),
-        ).to.be.revertedWith('Ownable: caller is not the owner');
+        ).to.be.revertedWithCustomError(context.erc725X, 'OwnableCallerNotTheOwner');
       });
     });
 
@@ -146,7 +146,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
       it('should revert', async () => {
         await expect(
           context.erc725X.connect(context.accounts.anyone).renounceOwnership(),
-        ).to.be.revertedWith('Ownable: caller is not the owner');
+        ).to.be.revertedWithCustomError(context.erc725X, 'OwnableCallerNotTheOwner');
       });
     });
   });
@@ -196,7 +196,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               context.erc725X
                 .connect(context.accounts.anyone)
                 .execute(txParams.Operation, txParams.to, txParams.value, txParams.data),
-            ).to.be.revertedWith('Ownable: caller is not the owner');
+            ).to.be.revertedWithCustomError(context.erc725X, 'OwnableCallerNotTheOwner');
           });
         });
       });
@@ -1624,7 +1624,7 @@ export const shouldBehaveLikeERC725X = (buildContext: () => Promise<ERC725XTestC
               context.erc725X
                 .connect(context.accounts.anyone)
                 .executeBatch(txParams.Operations, txParams.to, txParams.values, txParams.data),
-            ).to.be.revertedWith('Ownable: caller is not the owner');
+            ).to.be.revertedWithCustomError(context.erc725X, 'OwnableCallerNotTheOwner');
           });
         });
       });

--- a/implementations/test/ERC725X.test.ts
+++ b/implementations/test/ERC725X.test.ts
@@ -33,9 +33,12 @@ describe('ERC725X', () => {
           newOwner: ethers.constants.AddressZero,
         };
 
-        await expect(
-          new ERC725X__factory(accounts.owner).deploy(deployParams.newOwner),
-        ).to.be.revertedWith('Ownable: new owner is the zero address');
+        const contractToDeploy = new ERC725X__factory(accounts.owner);
+
+        await expect(contractToDeploy.deploy(deployParams.newOwner)).to.be.revertedWithCustomError(
+          contractToDeploy,
+          'OwnableCannotSetZeroAddressAsOwner',
+        );
       });
 
       it('should deploy and fund the contract with `msg.value`', async () => {
@@ -123,7 +126,7 @@ describe('ERC725X', () => {
       it('should revert when initializing with address(0) as owner', async () => {
         await expect(
           context.erc725X['initialize(address)'](ethers.constants.AddressZero),
-        ).to.be.revertedWith('Ownable: new owner is the zero address');
+        ).to.be.revertedWithCustomError(context.erc725X, 'OwnableCannotSetZeroAddressAsOwner');
       });
 
       describe('when initializing the contract', () => {

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -72,7 +72,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
           context.erc725Y
             .connect(context.accounts.anyone)
             .transferOwnership(context.accounts.anyone.address),
-        ).to.be.revertedWith('Ownable: caller is not the owner');
+        ).to.be.revertedWithCustomError(context.erc725Y, 'OwnableCallerNotTheOwner');
       });
     });
 
@@ -92,7 +92,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
       it('should revert', async () => {
         await expect(
           context.erc725Y.connect(context.accounts.anyone).renounceOwnership(),
-        ).to.be.revertedWith('Ownable: caller is not the owner');
+        ).to.be.revertedWithCustomError(context.erc725Y, 'OwnableCallerNotTheOwner');
       });
     });
   });
@@ -165,7 +165,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             context.erc725Y
               .connect(context.accounts.anyone)
               .setData(txParams.dataKey, txParams.dataValue),
-          ).to.be.revertedWith('Ownable: caller is not the owner');
+          ).to.be.revertedWithCustomError(context.erc725Y, 'OwnableCallerNotTheOwner');
 
           const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 
@@ -377,7 +377,7 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
             context.erc725Y
               .connect(context.accounts.anyone)
               .setDataBatch([txParams.dataKey], [txParams.dataValue]),
-          ).to.be.revertedWith('Ownable: caller is not the owner');
+          ).to.be.revertedWithCustomError(context.erc725Y, 'OwnableCallerNotTheOwner');
 
           const fetchedData = await context.erc725Y.getData(txParams.dataKey);
 

--- a/implementations/test/ERC725Y.behaviour.ts
+++ b/implementations/test/ERC725Y.behaviour.ts
@@ -64,6 +64,14 @@ export const shouldBehaveLikeERC725Y = (buildContext: () => Promise<ERC725YTestC
 
         expect(accountOwner).to.equal(context.accounts.anyone.address);
       });
+
+      it('should revert when transferring ownership to `address(0)`', async () => {
+        await expect(
+          context.erc725Y
+            .connect(context.accounts.owner)
+            .transferOwnership(ethers.constants.AddressZero),
+        ).to.be.revertedWithCustomError(context.erc725Y, 'OwnableCannotSetZeroAddressAsOwner');
+      });
     });
 
     describe('When non-owner is transferring ownership', () => {

--- a/implementations/test/ERC725Y.test.ts
+++ b/implementations/test/ERC725Y.test.ts
@@ -42,9 +42,12 @@ describe('ERC725Y', () => {
           newOwner: ethers.constants.AddressZero,
         };
 
-        await expect(
-          new ERC725Y__factory(accounts.owner).deploy(deployParams.newOwner),
-        ).to.be.revertedWith('Ownable: new owner is the zero address');
+        const contractToDeploy = new ERC725Y__factory(accounts.owner);
+
+        await expect(contractToDeploy.deploy(deployParams.newOwner)).to.be.revertedWithCustomError(
+          contractToDeploy,
+          'OwnableCannotSetZeroAddressAsOwner',
+        );
       });
 
       describe('once the contract was deployed', () => {
@@ -111,7 +114,7 @@ describe('ERC725Y', () => {
       it('should revert when initializing with address(0) as owner', async () => {
         await expect(
           context.erc725Y['initialize(address)'](ethers.constants.AddressZero),
-        ).to.be.revertedWith('Ownable: new owner is the zero address');
+        ).to.be.revertedWithCustomError(context.erc725Y, 'OwnableCannotSetZeroAddressAsOwner');
       });
 
       describe('when initializing the contract', () => {


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

- **Fixed:** minimum solc version required for ERC725Y is now `0.8.4` because of the use of custom errors: https://github.com/ethereum/solidity/releases/tag/v0.8.4
- **Refactor:** minimum solc version required for ERC725X and ERC725 is now `0.8.5` because of the use `bytes` to `bytesN` conversion: https://github.com/ethereum/solidity/releases/tag/v0.8.5

### 📦 Build

- Increase minimum `solc` compiler version because of full usage of custom `error` (currently states `pragma solidity ^0.8.0`

### ⚡️ Performance

Replace revert reason strings with custom errors for `OwnableUnset` and `address(0)` check on `transferOwnership()`, `constructor` and `initialize(address)` functions.

This reduces the deployment cost of an `ERC725` smart contract by -58,427 gas.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint` && `npm run lint:solidity`
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
