### PR TITLE
perf: use directly `IERC165` in inheritance instead of `ERC165`

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.5;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // modules
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 import {ERC725XCore} from "./ERC725XCore.sol";
@@ -36,7 +39,7 @@ contract ERC725 is ERC725XCore, ERC725YCore {
     }
 
     /**
-     * @inheritdoc ERC725XCore
+     * @inheritdoc IERC165
      */
     function supportsInterface(
         bytes4 interfaceId
@@ -44,6 +47,6 @@ contract ERC725 is ERC725XCore, ERC725YCore {
         return
             interfaceId == _INTERFACEID_ERC725X ||
             interfaceId == _INTERFACEID_ERC725Y ||
-            super.supportsInterface(interfaceId);
+            interfaceId == type(IERC165).interfaceId;
     }
 }

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.5;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // modules
 import {
     Initializable
@@ -44,7 +47,7 @@ abstract contract ERC725InitAbstract is
     }
 
     /**
-     * @inheritdoc ERC725XCore
+     * @inheritdoc IERC165
      */
     function supportsInterface(
         bytes4 interfaceId
@@ -52,6 +55,6 @@ abstract contract ERC725InitAbstract is
         return
             interfaceId == _INTERFACEID_ERC725X ||
             interfaceId == _INTERFACEID_ERC725Y ||
-            super.supportsInterface(interfaceId);
+            interfaceId == type(IERC165).interfaceId;
     }
 }

--- a/implementations/contracts/ERC725XCore.sol
+++ b/implementations/contracts/ERC725XCore.sol
@@ -11,7 +11,6 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 
 // modules
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 
 // constants
@@ -43,7 +42,7 @@ import {
  * It also allows to deploy and create new contracts via both the `create` and `create2` opcodes.
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system.
  */
-abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
+abstract contract ERC725XCore is OwnableUnset, IERC165, IERC725X {
     /**
      * @inheritdoc IERC725X
      * @custom:requirements
@@ -89,14 +88,14 @@ abstract contract ERC725XCore is OwnableUnset, ERC165, IERC725X {
     }
 
     /**
-     * @inheritdoc ERC165
+     * @inheritdoc IERC165
      */
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(IERC165, ERC165) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC725X ||
-            super.supportsInterface(interfaceId);
+            interfaceId == type(IERC165).interfaceId;
     }
 
     /**

--- a/implementations/contracts/ERC725YCore.sol
+++ b/implementations/contracts/ERC725YCore.sol
@@ -6,7 +6,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725Y} from "./interfaces/IERC725Y.sol";
 
 // modules
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUnset} from "./custom/OwnableUnset.sol";
 
 // constants
@@ -24,7 +23,7 @@ import {
  * @dev ERC725Y provides the ability to set arbitrary data key/value pairs that can be changed over time.
  * It is intended to standardise certain data key/value pairs to allow automated read and writes from/to the contract storage.
  */
-abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
+abstract contract ERC725YCore is OwnableUnset, IERC165, IERC725Y {
     /**
      * @dev Map `bytes32` data keys to their `bytes` data values.
      */
@@ -153,13 +152,13 @@ abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
     }
 
     /**
-     * @inheritdoc ERC165
+     * @inheritdoc IERC165
      */
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(IERC165, ERC165) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC725Y ||
-            super.supportsInterface(interfaceId);
+            interfaceId == type(IERC165).interfaceId;
     }
 }

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// interfaces
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-
 /**
  * @title The interface for the ERC725X sub-standard, a generic executor.
  * @dev ERC725X provides the ability to call arbitrary functions on any other smart contract (including itself).
@@ -11,7 +8,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  * It also allows to deploy and create new contracts via both the `create` and `create2` opcodes.
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system.
  */
-interface IERC725X is IERC165 {
+interface IERC725X {
     /**
      * @notice Deployed new contract at address `contractAddress` and funded with `value` wei (deployed using opcode: `operationType`).
      * @dev Emitted when a new contract was created and deployed.

--- a/implementations/contracts/interfaces/IERC725Y.sol
+++ b/implementations/contracts/interfaces/IERC725Y.sol
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// interfaces
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-
 /**
  * @title The interface for ERC725Y sub-standard, a generic data key/value store.
  * @dev ERC725Y provides the ability to set arbitrary data key/value pairs that can be changed over time.
  * It is intended to standardise certain data key/value pairs to allow automated read and writes from/to the contract storage.
  */
-interface IERC725Y is IERC165 {
+interface IERC725Y {
     /**
      * @notice The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`.
      * @dev Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.


### PR DESCRIPTION
# What does this PR introduce?

> **Note:** awaiting for #236 to be merged first.
> - [x] Change base branch to `develop` once #236 is merged.

## ♻️ Refactor

Remove `IERC165` from the inheritance list of `IERC725X` and `IERC725Y`.

## ⚡️ Performance

Reduce deployment cost by an extra -45.814 gas compared to #236 by using directly `IERC165` in the inheritance instead of `ERC165` and calling `super.supportsInterface`.

The checks for interface ID ERC165 are directly inlined as a result inside the `supportsInterface(bytes4)` function of `ERC725XCore`, `ERC725YCore` and `ERC725` contracts.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint` && `npm run lint:solidity`
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`

### Previous gas cost (`develop` branch)

```
···············|·······················································|·············|··············|·············|···············|··············
|  Contract    ·  Method                                               ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  execute(uint256,address,uint256,bytes)               ·      34726  ·      127088  ·      47290  ·          114  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  executeBatch(uint256[],address[],uint256[],bytes[])  ·      60485  ·      155455  ·      92070  ·           16  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  renounceOwnership()                                  ·      31283  ·       31328  ·      31306  ·            4  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  setData(bytes32,bytes)                               ·      32983  ·     8244933  ·    1494244  ·           17  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  setDataBatch(bytes32[],bytes[])                      ·      35151  ·     8247117  ·    1417890  ·           18  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  transferOwnership(address)                           ·      32069  ·       32091  ·      32084  ·            6  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Init  ·  initialize(address)                                  ·      51749  ·       51771  ·      51749  ·          124  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  execute(uint256,address,uint256,bytes)               ·      31954  ·      124204  ·      44508  ·          114  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  executeBatch(uint256[],address[],uint256[],bytes[])  ·      57611  ·      152526  ·      89181  ·           16  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  renounceOwnership()                                  ·          -  ·           -  ·      23661  ·            2  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  transferOwnership(address)                           ·          -  ·           -  ·      29219  ·            2  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  renounceOwnership()                                  ·          -  ·           -  ·      23662  ·            2  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  setData(bytes32,bytes)                               ·      30252  ·     8239813  ·    1491087  ·           17  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  setDataBatch(bytes32[],bytes[])                      ·      32396  ·     8241968  ·    1414731  ·           18  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  transferOwnership(address)                           ·          -  ·           -  ·      29197  ·            4  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  Deployments                                                         ·                                          ·  % of limit   ·             │
·······································································|·············|··············|·············|···············|··············
|  ERC725                                                              ·          -  ·           -  ·    2393988  ·          8 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725Init                                                          ·          -  ·           -  ·    2600372  ·        8.7 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725X                                                             ·          -  ·           -  ·    1832301  ·        6.1 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725XInit                                                         ·          -  ·           -  ·    2044314  ·        6.8 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725Y                                                             ·          -  ·           -  ·    1134143  ·        3.8 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725YInit                                                         ·          -  ·           -  ·    1344141  ·        4.5 %  ·          -  │
·----------------------------------------------------------------------|-------------|--------------|-------------|---------------|-------------·
```

### New Gas costs (this branch)

```
·----------------------------------------------------------------------|----------------------------|-------------|-----------------------------·
|                         Solc version: 0.8.17                         ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 30000000 gas  │
·······································································|····························|·············|······························
|  Methods                                                                                                                                      │
···············|·······················································|·············|··············|·············|···············|··············
|  Contract    ·  Method                                               ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  execute(uint256,address,uint256,bytes)               ·      34726  ·      127088  ·      47290  ·          114  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  executeBatch(uint256[],address[],uint256[],bytes[])  ·      60485  ·      155455  ·      92070  ·           16  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  renounceOwnership()                                  ·      31283  ·       31328  ·      31306  ·            4  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  setData(bytes32,bytes)                               ·      32983  ·     8083629  ·    1465779  ·           17  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  setDataBatch(bytes32[],bytes[])                      ·      35151  ·     8085813  ·    1391006  ·           18  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725      ·  transferOwnership(address)                           ·      32069  ·       32091  ·      32084  ·            6  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Init  ·  initialize(address)                                  ·      51749  ·       51771  ·      51749  ·          124  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  execute(uint256,address,uint256,bytes)               ·      31954  ·      124204  ·      44508  ·          114  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  executeBatch(uint256[],address[],uint256[],bytes[])  ·      57611  ·      152526  ·      89181  ·           16  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  renounceOwnership()                                  ·          -  ·           -  ·      23661  ·            2  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725X     ·  transferOwnership(address)                           ·          -  ·           -  ·      29219  ·            2  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  renounceOwnership()                                  ·          -  ·           -  ·      23662  ·            2  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  setData(bytes32,bytes)                               ·      30252  ·     8078561  ·    1462631  ·           17  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  setDataBatch(bytes32[],bytes[])                      ·      32396  ·     8080716  ·    1387855  ·           18  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  ERC725Y     ·  transferOwnership(address)                           ·          -  ·           -  ·      29197  ·            4  ·          -  │
···············|·······················································|·············|··············|·············|···············|··············
|  Deployments                                                         ·                                          ·  % of limit   ·             │
·······································································|·············|··············|·············|···············|··············
|  ERC725                                                              ·          -  ·           -  ·    2348169  ·        7.8 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725Init                                                          ·          -  ·           -  ·    2554540  ·        8.5 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725X                                                             ·          -  ·           -  ·    1828454  ·        6.1 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725XInit                                                         ·          -  ·           -  ·    2040383  ·        6.8 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725Y                                                             ·          -  ·           -  ·    1130213  ·        3.8 %  ·          -  │
·······································································|·············|··············|·············|···············|··············
|  ERC725YInit                                                         ·          -  ·           -  ·    1340258  ·        4.5 %  ·          -  │
·----------------------------------------------------------------------|-------------|--------------|-------------|---------------|-------------·
```
