### PR TITLE
refactor: index selector over value in Executed event

### DIFF
--- a/docs/ERC-725.md
+++ b/docs/ERC-725.md
@@ -139,7 +139,7 @@ _Returns:_ `bytes[]` , array list of returned data of the called function, or th
 #### Executed
 
 ```solidity
-event Executed(uint256 indexed operationType, address indexed target, uint256 indexed value, bytes4 data);
+event Executed(uint256 indexed operationType, address indexed target, uint256 value, bytes4 indexed selector);
 ```
 
 MUST be triggered when `execute` creates a new call using the `operationType` `0`, `3`, `4`.
@@ -147,7 +147,7 @@ MUST be triggered when `execute` creates a new call using the `operationType` `0
 #### ContractCreated
 
 ```solidity
-event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
+event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 value, bytes32 indexed salt);
 ```
 
 MUST be triggered when `execute` creates a new contract using the `operationType` `1`, `2`.
@@ -283,8 +283,8 @@ When using the operation type `4` for `delegatecall`, it is important to conside
 pragma solidity >=0.5.0 <0.7.0;
 
 interface IERC725X  /* is ERC165, ERC173 */ {
-    event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
-    event Executed(uint256 indexed operationType, address indexed target, uint256 indexed  value, bytes4 data);
+    event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 value, bytes32 indexed salt);
+    event Executed(uint256 indexed operationType, address indexed target, uint256 value, bytes4 indexed selector);
 
     function execute(uint256 operationType, address target, uint256 value, bytes memory data) external payable returns(bytes memory);
 

--- a/implementations/constants.js
+++ b/implementations/constants.js
@@ -73,8 +73,8 @@ const EventSignatures = {
      * event ContractCreated(
      *     uint256 indexed _operation,
      *     address indexed _contractAddress,
-     *     uint256 indexed _value
-     *     bytes32 _salt
+     *     uint256 _value
+     *     bytes32 indexed _salt
      * );
      *
      * signature = keccak256('ContractCreated(uint256,address,uint256,bytes32)')
@@ -84,8 +84,8 @@ const EventSignatures = {
      * event Executed(
      *      uint256 indexed _operation,
      *      address indexed _to,
-     *      uint256 indexed _value,
-     *      bytes4 _data
+     *      uint256 _value,
+     *      bytes4 indexed _selector
      * );
      *
      * signature = keccak256('Executed(uint256,address,uint256,bytes4)')

--- a/implementations/contracts/interfaces/IERC725X.sol
+++ b/implementations/contracts/interfaces/IERC725X.sol
@@ -23,8 +23,8 @@ interface IERC725X is IERC165 {
     event ContractCreated(
         uint256 indexed operationType,
         address indexed contractAddress,
-        uint256 indexed value,
-        bytes32 salt
+        uint256 value,
+        bytes32 indexed salt
     );
 
     /**
@@ -38,8 +38,8 @@ interface IERC725X is IERC165 {
     event Executed(
         uint256 indexed operationType,
         address indexed target,
-        uint256 indexed value,
-        bytes4 selector
+        uint256 value,
+        bytes4 indexed selector
     );
 
     /**


### PR DESCRIPTION
# What does this PR introduce? 

- Update `Executed` so that `selector` is indexed over `value` 
- Update `ContractCreated ` so that `salt` is indexed over `value`