### PR TITLE
chore: prepare release 7.0.0

### DIFF
--- a/implementations/CHANGELOG.md
+++ b/implementations/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.1.0](https://github.com/ERC725Alliance/ERC725/compare/v6.0.0...v6.1.0) (2023-11-27)
+
+### Refactor
+
+- Update `Executed` event in ERC725X to index `selector` instead of `value` ([#246](https://github.com/ERC725Alliance/ERC725/pull/246))
+- Update `ContractCreated` event in ERC725X to index `salt` instead of `value` ([#246](https://github.com/ERC725Alliance/ERC725/pull/246))
+
 ## [6.0.0](https://github.com/ERC725Alliance/ERC725/compare/v5.2.0...v6.0.0) (2023-10-10)
 
 ### ⚠ BREAKING CHANGES

--- a/implementations/CHANGELOG.md
+++ b/implementations/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [6.1.0](https://github.com/ERC725Alliance/ERC725/compare/v6.0.0...v6.1.0) (2023-11-27)
+## [7.0.0](https://github.com/ERC725Alliance/ERC725/compare/v6.0.0...v7.0.0) (2023-11-27)
+
+### ⚠ BREAKING CHANGES
 
 ### Refactor
 

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/smart-contracts",
-      "version": "6.1.0",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.3",

--- a/implementations/package-lock.json
+++ b/implementations/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/smart-contracts",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.3",

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "ERC725 contract implementations",
   "homepage": "https://erc725alliance.org",
   "repository": {

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "ERC725 contract implementations",
   "homepage": "https://erc725alliance.org",
   "repository": {


### PR DESCRIPTION
# What does this PR introduce?

- Prepare a new minor release
- Bump version in `package.json` and `package-lock.json` from `6.0.0` > `7.0.0`
- Add release details in `CHANGELOG.md`
