### PR TITLE
chore: bump version to `8.0.0` in `package.json`

### DIFF
--- a/implementations/package.json
+++ b/implementations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc725/smart-contracts",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "ERC725 contract implementations",
   "homepage": "https://erc725alliance.org",
   "repository": {


### PR DESCRIPTION
I thought that this repo had release please and that the version will be incremented automatically. But it is not the case.

PR #263 had no effect, so re-bumping it again.