### PR TITLE
fix: add warning comments about `constructor` / `initialize` functions being payable by default

### DIFF
--- a/implementations/contracts/ERC725.sol
+++ b/implementations/contracts/ERC725.sol
@@ -8,14 +8,20 @@ import {ERC725Y} from "./ERC725Y.sol";
 /**
  * @title ERC725 bundle.
  * @author Fabian Vogelsteller <fabian@lukso.network>
+ *
  * @dev Bundle ERC725X and ERC725Y together into one smart contract.
  *
- * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function.
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
+ * Despite that, its constructor is payable to allow the possibility to fund the contract on deployment.
+ * The reason for this design is because Solidity does not allow to override a function from non payable to payable (and vice versa).
+ * Therefore, the constructor is kept as "payable" to allow it by default. Any native tokens sent to the contract on deployment can
+ * be re-transferred using the {execute} or {executeBatch} functions with the `value` parameter.
+ * A functionality to handle receiving native tokens can be added by extending the contract through inheritance.
  */
 contract ERC725 is ERC725X, ERC725Y {
     /**
      * @notice Deploying an ERC725 smart contract and setting address `initialOwner` as the contract owner.
-     * @dev Deploy a new ERC725 contract with the provided `initialOwner` as the contract {owner}.
+     * @dev Deploy a new ERC725 contract with the provided `initialOwner` as the contract {owner}, and optionally fund the contract on deployment.
      * @param initialOwner the owner of the contract.
      *
      * @custom:requirements

--- a/implementations/contracts/ERC725Init.sol
+++ b/implementations/contracts/ERC725Init.sol
@@ -7,9 +7,15 @@ import {ERC725InitAbstract} from "./ERC725InitAbstract.sol";
 /**
  * @title Deployable Proxy Implementation of ERC725 bundle.
  * @author Fabian Vogelsteller <fabian@lukso.network>
+ *
  * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract.
  *
- * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function.
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
+ * Despite that, its `initialize(...)` function is payable to allow the possibility to fund the contract on initialization.
+ * The reason for this design is because Solidity does not allow to override a function from non payable to payable (and vice versa).
+ * Therefore, the `initialize(...)` function is kept as "payable" to allow it by default. Any native tokens sent to the contract on initialization
+ * can be re-transferred using the {execute} or {executeBatch} functions with the `value` parameter.
+ * A functionality to handle receiving native tokens can be added by extending the contract through inheritance.
  */
 contract ERC725Init is ERC725InitAbstract {
     /**

--- a/implementations/contracts/ERC725InitAbstract.sol
+++ b/implementations/contracts/ERC725InitAbstract.sol
@@ -11,9 +11,10 @@ import {OwnableCannotSetZeroAddressAsOwner} from "./errors.sol";
 /**
  * @title Inheritable Proxy Implementation of ERC725 bundle
  * @author Fabian Vogelsteller <fabian@lukso.network>
+ *
  * @dev Bundles ERC725XInit and ERC725YInit together into one smart contract.
  *
- * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function.
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
  */
 abstract contract ERC725InitAbstract is
     ERC725XInitAbstract,

--- a/implementations/contracts/ERC725X.sol
+++ b/implementations/contracts/ERC725X.sol
@@ -40,10 +40,18 @@ import {
 /**
  * @title Deployable implementation with `constructor` of ERC725X sub-standard, a generic executor.
  * @author Fabian Vogelsteller <fabian@lukso.network> and <CJ42>, <YamenMerhi>, <B00ste>, <SkimaHarvey>
+ *
  * @dev ERC725X provides the ability to call arbitrary functions on any other smart contract (including itself).
  * It allows to use different type of message calls to interact with addresses such as `call`, `staticcall` and `delegatecall`.
  * It also allows to deploy and create new contracts via both the `create` and `create2` opcodes.
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system.
+ *
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
+ * Despite that, its constructor is payable to allow the possibility to fund the contract on deployment.
+ * The reason for this design is because Solidity does not allow to override a function from non payable to payable (and vice versa).
+ * Therefore, the constructor is kept as "payable" to allow it by default. Any native tokens sent to the contract on deployment can
+ * be re-transferred using the {execute} or {executeBatch} functions with the `value` parameter.
+ * A functionality to handle receiving native tokens can be added by extending the contract through inheritance.
  */
 contract ERC725X is Ownable, ERC165, IERC725X {
     /**

--- a/implementations/contracts/ERC725XInit.sol
+++ b/implementations/contracts/ERC725XInit.sol
@@ -7,10 +7,18 @@ import {ERC725XInitAbstract} from "./ERC725XInitAbstract.sol";
 /**
  * @title Deployable Proxy Implementation of ERC725X, a generic executor.
  * @author Fabian Vogelsteller <fabian@lukso.network>
+ *
  * @dev ERC725X provides the ability to call arbitrary functions on any other smart contract (including itself).
  * It allows to use different type of message calls to interact with addresses such as `call`, `staticcall` and `delegatecall`.
  * It also allows to deploy and create new contracts via both the `create` and `create2` opcodes.
  * This is the basis for a smart contract based account system, but could also be used as a proxy account system.
+ *
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
+ * Despite that, its `initialize(...)` function is payable to allow the possibility to fund the contract on initialization.
+ * The reason for this design is because Solidity does not allow to override a function from non payable to payable (and vice versa).
+ * Therefore, the `initialize(...)` function is kept as "payable" to allow it by default. Any native tokens sent to the contract on initialization
+ * can be re-transferred using the {execute} or {executeBatch} functions with the `value` parameter.
+ * A functionality to handle receiving native tokens can be added by extending the contract through inheritance.
  */
 contract ERC725XInit is ERC725XInitAbstract {
     /**

--- a/implementations/contracts/ERC725XInitAbstract.sol
+++ b/implementations/contracts/ERC725XInitAbstract.sol
@@ -44,6 +44,7 @@ import {
 /**
  * @title Inheritable Proxy Implementation of ERC725X sub-standard, a generic executor.
  * @author Fabian Vogelsteller <fabian@lukso.network> and <CJ42>, <YamenMerhi>, <B00ste>, <SkimaHarvey>
+ *
  * @dev ERC725X provides the ability to call arbitrary functions on any other smart contract (including itself).
  * It allows to use different type of message calls to interact with addresses such as `call`, `staticcall` and `delegatecall`.
  * It also allows to deploy and create new contracts via both the `create` and `create2` opcodes.

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -94,7 +94,7 @@ contract ERC725Y is Ownable, ERC165, IERC725Y {
      * @custom:warning
      * **Note for developers:** despite the fact that this function is set as `payable`, the function is not intended to receive value
      * (= native tokens). **An additional check has been implemented to ensure that `msg.value` sent was equal to 0**.
-     * If you want to allow this function to receive value in your inheriting contract, this function can be overriden to remove this check.
+     * If you want to allow this function to receive value in your inheriting contract, this function can be overridden to remove this check.
      *
      * @custom:events {DataChanged} event.
      */
@@ -114,7 +114,7 @@ contract ERC725Y is Ownable, ERC165, IERC725Y {
      * @custom:warning
      * **Note for developers:** despite the fact that this function is set as `payable`, the function is not intended to receive value
      * (= native tokens). **An additional check has been implemented to ensure that `msg.value` sent was equal to 0**.
-     * If you want to allow this function to receive value in your inheriting contract, this function can be overriden to remove this check.
+     * If you want to allow this function to receive value in your inheriting contract, this function can be overridden to remove this check.
      *
      * @custom:events {DataChanged} event **for each data key/value pair set**.
      */

--- a/implementations/contracts/ERC725Y.sol
+++ b/implementations/contracts/ERC725Y.sol
@@ -22,8 +22,19 @@ import {
 /**
  * @title Deployable implementation with `constructor` of ERC725Y sub-standard, a generic data key/value store.
  * @author Fabian Vogelsteller <fabian@lukso.network> and <CJ42>, <YamenMerhi>, <B00ste>, <SkimaHarvey>
+ *
  * @dev ERC725Y provides the ability to set arbitrary data key/value pairs that can be changed over time.
  * It is intended to standardise certain data key/value pairs to allow automated read and writes from/to the contract storage.
+ *
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
+ * Despite that, its constructor is payable to allow the possibility to fund the contract on deployment.
+ * The reason for this design is because Solidity does not allow to override a function from non payable to payable (and vice versa).
+ * Therefore, the constructor is kept as "payable" to allow it by default. A functionality to handle receiving native tokens can be
+ * added by extending the contract through inheritance.
+ *
+ * @custom:warning Despite that this contract can receive native tokens via the `constructor`, it does not contain any method to transfer
+ * the tokens back. If you are planning to fund the contract on deployment, make sure to create or include functionalities to transfer
+ * these tokens, so to prevent them from being stuck in the contract.
  */
 contract ERC725Y is Ownable, ERC165, IERC725Y {
     /**

--- a/implementations/contracts/ERC725YInit.sol
+++ b/implementations/contracts/ERC725YInit.sol
@@ -7,8 +7,19 @@ import {ERC725YInitAbstract} from "./ERC725YInitAbstract.sol";
 /**
  * @title Deployable Proxy Implementation of ERC725Y, a generic data key/value store.
  * @author Fabian Vogelsteller <fabian@lukso.network> and <CJ42>, <YamenMerhi>, <B00ste>, <SkimaHarvey>
+ *
  * @dev ERC725Y provides the ability to set arbitrary data key/value pairs that can be changed over time.
  * It is intended to standardise certain data key/value pairs to allow automated read and writes from/to the contract storage.
+ *
+ * @custom:warning This implementation does not have by default a `receive()` or `fallback()` function to receive native tokens.
+ * Despite that, its `initialize(...)` function is payable to allow the possibility to fund the contract on initialization.
+ * The reason for this design is because Solidity does not allow to override a function from non payable to payable (and vice versa).
+ * Therefore, the `initialize(...)` function is kept as "payable" to allow it by default. A functionality to handle receiving native
+ * tokens can be added by extending the contract through inheritance.
+ *
+ * @custom:warning Despite that this contract can receive native tokens via the `constructor`, it does not contain any method to transfer
+ * the tokens back. If you are planning to fund the contract on initialization, make sure to create or include functionalities to transfer
+ * these tokens, so to prevent them from being stuck in the contract.
  */
 contract ERC725YInit is ERC725YInitAbstract {
     /**

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -93,7 +93,7 @@ abstract contract ERC725YInitAbstract is
      * @custom:warning
      * **Note for developers:** despite the fact that this function is set as `payable`, the function is not intended to receive value
      * (= native tokens). **An additional check has been implemented to ensure that `msg.value` sent was equal to 0**.
-     * If you want to allow this function to receive value in your inheriting contract, this function can be overriden to remove this check.
+     * If you want to allow this function to receive value in your inheriting contract, this function can be overridden to remove this check.
      *
      * @custom:events {DataChanged} event.
      */
@@ -113,7 +113,7 @@ abstract contract ERC725YInitAbstract is
      * @custom:warning
      * **Note for developers:** despite the fact that this function is set as `payable`, the function is not intended to receive value
      * (= native tokens). **An additional check has been implemented to ensure that `msg.value` sent was equal to 0**.
-     * If you want to allow this function to receive value in your inheriting contract, this function can be overriden to remove this check.
+     * If you want to allow this function to receive value in your inheriting contract, this function can be overridden to remove this check.
      *
      * @custom:events {DataChanged} event **for each data key/value pair set**.
      */

--- a/implementations/contracts/ERC725YInitAbstract.sol
+++ b/implementations/contracts/ERC725YInitAbstract.sol
@@ -26,6 +26,7 @@ import {
 /**
  * @title Inheritable Proxy Implementation of ERC725Y sub-standard, a generic data key/value store
  * @author Fabian Vogelsteller <fabian@lukso.network> and <CJ42>, <YamenMerhi>, <B00ste>, <SkimaHarvey>
+ *
  * @dev ERC725Y provides the ability to set arbitrary data key/value pairs that can be changed over time.
  * It is intended to standardise certain data key/value pairs to allow automated read and writes from/to the contract storage.
  */


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

Add suggestions from Milo Truck audit on ERC725 smart contracts (including typos)

### PR Checklist


- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run lint` && `npm run lint:solidity`
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
