### PR TITLE
build: upgrade `.tool-versions` file to use nodejs version supported by Hardhat dependency

### DIFF
--- a/implementations/.tool-versions
+++ b/implementations/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 16.19.0
+nodejs 18

--- a/implementations/package.json
+++ b/implementations/package.json
@@ -2,6 +2,8 @@
   "name": "@erc725/smart-contracts",
   "version": "8.0.0",
   "description": "ERC725 contract implementations",
+  "author": "Fabian Vogelsteller <fabian@lukso.network>",
+  "license": "Apache-2.0",
   "homepage": "https://erc725alliance.org",
   "repository": {
     "type": "git",
@@ -31,8 +33,6 @@
     "analyse": "sh solc.sh",
     "format": "prettier --write ."
   },
-  "author": "Fabian Vogelsteller <fabian@lukso.network>",
-  "license": "Apache-2.0",
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.6",
     "@openzeppelin/contracts-upgradeable": "^4.9.6",


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build

Hardhat was signaling warnings that this repository is using a version of nodejs that is not maintained and supported by Hardhat anymore. In fact, the `.tool-versions` file list node v16. See Node.js releases for more details. https://github.com/nodejs/Release

- change to node v18, which is the currently supported version

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/75339694-d0eb-4e4d-ad8b-af311a272a6a" />

